### PR TITLE
Rows interface

### DIFF
--- a/db.go
+++ b/db.go
@@ -30,7 +30,7 @@ func (db *DB) Name() string {
 }
 
 // AllDocs returns a list of all documents in the database.
-func (db *DB) AllDocs(ctx context.Context, options ...Options) (*RowsWrapper, error) {
+func (db *DB) AllDocs(ctx context.Context, options ...Options) (RowsWrapper, error) {
 	opts, err := mergeOptions(options...)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func (db *DB) AllDocs(ctx context.Context, options ...Options) (*RowsWrapper, er
 // Query executes the specified view function from the specified design
 // document. ddoc and view may or may not be be prefixed with '_design/'
 // and '_view/' respectively. No other
-func (db *DB) Query(ctx context.Context, ddoc, view string, options ...Options) (*Rows, error) {
+func (db *DB) Query(ctx context.Context, ddoc, view string, options ...Options) (RowsWrapper, error) {
 	opts, err := mergeOptions(options...)
 	if err != nil {
 		return nil, err

--- a/db.go
+++ b/db.go
@@ -30,7 +30,7 @@ func (db *DB) Name() string {
 }
 
 // AllDocs returns a list of all documents in the database.
-func (db *DB) AllDocs(ctx context.Context, options ...Options) (*Rows, error) {
+func (db *DB) AllDocs(ctx context.Context, options ...Options) (*RowsWrapper, error) {
 	opts, err := mergeOptions(options...)
 	if err != nil {
 		return nil, err

--- a/db_test.go
+++ b/db_test.go
@@ -83,9 +83,13 @@ func TestAllDocs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := test.db.AllDocs(context.Background(), test.options)
+			var resultTypeCast *Rows
+			if result != nil {
+				resultTypeCast = result.(*Rows)
+				resultTypeCast.cancel = nil // Determinism
+			}
 			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := diff.Interface(test.expected, result); d != nil {
+			if d := diff.Interface(test.expected, resultTypeCast); d != nil {
 				t.Error(d)
 			}
 		})
@@ -152,8 +156,9 @@ func TestQuery(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := test.db.Query(context.Background(), test.ddoc, test.view, test.options)
 			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := diff.Interface(test.expected, result); d != nil {
+			resultTypeCast := result.(*Rows)
+			resultTypeCast.cancel = nil // Determinism
+			if d := diff.Interface(test.expected, resultTypeCast); d != nil {
 				t.Error(d)
 			}
 		})

--- a/find.go
+++ b/find.go
@@ -12,7 +12,7 @@ var findNotImplemented = errors.Status(StatusNotImplemented, "kivik: driver does
 // Find executes a query using the new /_find interface. The query must be
 // JSON-marshalable to a valid query.
 // See http://docs.couchdb.org/en/2.0.0/api/database/find.html#db-find
-func (db *DB) Find(ctx context.Context, query interface{}) (*Rows, error) {
+func (db *DB) Find(ctx context.Context, query interface{}) (RowsWrapper, error) {
 	if finder, ok := db.driverDB.(driver.Finder); ok {
 		rowsi, err := finder.Find(ctx, query)
 		if err != nil {

--- a/find_test.go
+++ b/find_test.go
@@ -69,9 +69,13 @@ func TestFind(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := test.db.Find(context.Background(), test.query)
+			var resultTypeCast *Rows
+			if result != nil {
+				resultTypeCast = result.(*Rows)
+				resultTypeCast.cancel = nil // Determinism
+			}
 			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := diff.Interface(test.expected, result); d != nil {
+			if d := diff.Interface(test.expected, resultTypeCast); d != nil {
 				t.Error(d)
 			}
 		})

--- a/rows.go
+++ b/rows.go
@@ -56,7 +56,7 @@ var _ iterator = &rowsIterator{}
 
 func (r *rowsIterator) Next(i interface{}) error { return r.Rows.Next(i.(*driver.Row)) }
 
-func newRows(ctx context.Context, rowsi driver.Rows) *Rows {
+func newRows(ctx context.Context, rowsi driver.Rows) RowsWrapper {
 	return &Rows{
 		iter:  newIterator(ctx, &rowsIterator{rowsi}, &driver.Row{}),
 		rowsi: rowsi,

--- a/rows.go
+++ b/rows.go
@@ -8,7 +8,21 @@ import (
 	"github.com/go-kivik/kivik/errors"
 )
 
-// Rows is an iterator over a a multi-value query.
+type RowsWrapper interface {
+	Next() bool
+	Err() error
+	Close() error
+	ScanDoc(interface{}) error
+	ScanValue(interface{}) error
+	ID() string
+	Key() string
+	Offset() int64
+	TotalRows() int64
+	UpdateSeq() string
+	Warning() string
+	Bookmark() string
+}
+
 type Rows struct {
 	*iter
 	rowsi driver.Rows


### PR DESCRIPTION
I needed a way mock the responses for the `AllDocs` and `Query` functions. This interface did the trick. 

This works when I use glide to switch out my branch for the `go-kivik` imports in my project, but I haven't been able to get your tests to run locally because of the import paths.

I can update the `RowsWrapper` name if you have a better idea.