### PR TITLE
Add BulkGet support

### DIFF
--- a/db.go
+++ b/db.go
@@ -572,3 +572,24 @@ func (db *DB) Purge(ctx context.Context, docRevMap map[string][]string) (*PurgeR
 	}
 	return nil, errors.Status(StatusNotImplemented, "kivik: purge not supported by driver")
 }
+
+// BulkGet can be called to query several documents in bulk. It is well suited
+// for fetching a specific revision of documents, as replicators do for example,
+// or for getting revision history.
+//
+// See http://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-get
+func (db *DB) BulkGet(ctx context.Context, docs []driver.BulkDocReference, options ...Options) (*Rows, error) {
+	bulkGetter, ok := db.driverDB.(driver.BulkGetter)
+	if !ok {
+		return nil, errors.Status(StatusNotImplemented, "kivik: bulk get not supported by driver")
+	}
+	opts, err := mergeOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+	rowsi, err := bulkGetter.BulkGet(ctx, docs, opts)
+	if err != nil {
+		return nil, err
+	}
+	return newRows(ctx, rowsi), nil
+}

--- a/driver/bulkget.go
+++ b/driver/bulkget.go
@@ -1,0 +1,17 @@
+package driver
+
+import "context"
+
+// BulkDocReference is a reference document given in a BulkGet query.
+type BulkDocReference struct {
+	ID        string `json:"id"`
+	Rev       string `json:"rev,omitempty"`
+	AttsSince string `json:"atts_since,omitempty"`
+}
+
+// BulkGetter is an optional interface which may be implemented by a driver to
+// support bulk get operations.
+type BulkGetter interface {
+	// BulkGet uses the _bulk_get interface to fetch multiple documents in a single query.
+	BulkGet(ctx context.Context, docs []BulkDocReference, options map[string]interface{}) (Rows, error)
+}

--- a/mock/db.go
+++ b/mock/db.go
@@ -237,3 +237,16 @@ var _ driver.Purger = &Purger{}
 func (db *Purger) Purge(ctx context.Context, docMap map[string][]string) (*driver.PurgeResult, error) {
 	return db.PurgeFunc(ctx, docMap)
 }
+
+// BulkGetter mocks a driver.DB and driver.BulkGetter
+type BulkGetter struct {
+	*DB
+	BulkGetFunc func(context.Context, []driver.BulkDocReference, map[string]interface{}) (driver.Rows, error)
+}
+
+var _ driver.BulkGetter = &BulkGetter{}
+
+// BulkGet calls db.BulkGetFunc
+func (db *BulkGetter) BulkGet(ctx context.Context, docs []driver.BulkDocReference, opts map[string]interface{}) (driver.Rows, error) {
+	return db.BulkGetFunc(ctx, docs, opts)
+}


### PR DESCRIPTION
Alternative to #340. See also https://github.com/go-kivik/couchdb/pull/139

The purpose of this PR is to explore whether adding BulkGet support can be done without extending the [`Rows`](https://godoc.org/github.com/go-kivik/kivik#Rows) interface. I believe I have a working solution, but some work is still needed on the CouchDB driver.