### PR TITLE
Add BulkDocReference type to kivik package, so consumers don't need to

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1882,7 +1882,7 @@ func TestBulkGet(t *testing.T) {
 	type bulkGetTest struct {
 		name    string
 		db      *DB
-		docs    []driver.BulkDocReference
+		docs    []BulkDocReference
 		options Options
 
 		expected *Rows

--- a/driver/bulkget.go
+++ b/driver/bulkget.go
@@ -2,7 +2,7 @@ package driver
 
 import "context"
 
-// BulkDocReference is a reference document given in a BulkGet query.
+// BulkDocReference is a reference to a document given in a BulkGet query.
 type BulkDocReference struct {
 	ID        string `json:"id"`
 	Rev       string `json:"rev,omitempty"`


### PR DESCRIPTION
directly access 'driver' package.