### PR TITLE
Defer DB() and CreateDB() errors

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -92,10 +92,6 @@ func (r *BulkResults) UpdateErr() error {
 // As with Put, each individual document may be a JSON-marshable object, or a
 // raw JSON string in a []byte, json.RawMessage, or io.Reader.
 func (db *DB) BulkDocs(ctx context.Context, docs interface{}, options ...Options) (*BulkResults, error) {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
 	docsi, err := docsInterfaceSlice(docs)
 	if err != nil {
 		if _, ok := err.(errNotSlice); ok {
@@ -106,6 +102,7 @@ func (db *DB) BulkDocs(ctx context.Context, docs interface{}, options ...Options
 	if len(docsi) == 0 {
 		return nil, &Error{HTTPStatus: http.StatusBadRequest, Err: errors.New("kivik: no documents provided")}
 	}
+	opts := mergeOptions(options...)
 	if bulkDocer, ok := db.driverDB.(driver.BulkDocer); ok {
 		bulki, err := bulkDocer.BulkDocs(ctx, docsi, opts)
 		if err != nil {

--- a/changes.go
+++ b/changes.go
@@ -77,11 +77,7 @@ func (c *Changes) ScanDoc(dest interface{}) error {
 // open until explicitly closed, or an error is encountered.
 // See http://couchdb.readthedocs.io/en/latest/api/database/changes.html#get--db-_changes
 func (db *DB) Changes(ctx context.Context, options ...Options) (*Changes, error) {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
-	changesi, err := db.driverDB.Changes(ctx, opts)
+	changesi, err := db.driverDB.Changes(ctx, mergeOptions(options...))
 	if err != nil {
 		return nil, err
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -18,11 +18,7 @@ func (c *Client) ClusterStatus(ctx context.Context, options ...Options) (string,
 	if !ok {
 		return "", clusterNotImplemented
 	}
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return "", err
-	}
-	return cluster.ClusterStatus(ctx, opts)
+	return cluster.ClusterStatus(ctx, mergeOptions(options...))
 }
 
 // ClusterSetup performs the requested cluster action. action should be

--- a/db_test.go
+++ b/db_test.go
@@ -614,6 +614,7 @@ func TestSetSecurity(t *testing.T) {
 	}{
 		{
 			name:   "nil security",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: security required",
 		},
@@ -825,11 +826,13 @@ func TestCopy(t *testing.T) {
 	}{
 		{
 			name:   "missing target",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: targetID required",
 		},
 		{
 			name:   "missing source",
+			db:     &DB{},
 			target: "foo",
 			status: StatusBadRequest,
 			err:    "kivik: sourceID required",
@@ -1063,6 +1066,7 @@ func TestPut(t *testing.T) {
 	tests := []putTest{
 		{
 			name:   "no docID",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: docID required",
 		},
@@ -1093,6 +1097,7 @@ func TestPut(t *testing.T) {
 		},
 		{
 			name:   "InvalidJSON",
+			db:     &DB{},
 			docID:  "foo",
 			input:  []byte("Something bogus"),
 			status: StatusBadAPICall,
@@ -1136,6 +1141,7 @@ func TestPut(t *testing.T) {
 		},
 		{
 			name:   "ErrorReader",
+			db:     &DB{},
 			docID:  "foo",
 			input:  &errorReader{},
 			status: http.StatusBadRequest,
@@ -1319,6 +1325,7 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			name:   "no doc ID",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: docID required",
 		},
@@ -1404,11 +1411,13 @@ func TestPutAttachment(t *testing.T) {
 		},
 		{
 			name:   "no doc id",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: docID required",
 		},
 		{
 			name:   "no filename",
+			db:     &DB{},
 			docID:  "foo",
 			att:    &Attachment{},
 			status: StatusBadRequest,
@@ -1485,11 +1494,13 @@ func TestDeleteAttachment(t *testing.T) {
 	}{
 		{
 			name:   "missing doc id",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: docID required",
 		},
 		{
 			name:   "missing filename",
+			db:     &DB{},
 			docID:  "foo",
 			status: StatusBadRequest,
 			err:    "kivik: filename required",
@@ -1616,11 +1627,13 @@ func TestGetAttachment(t *testing.T) {
 		},
 		{
 			name:   "no docID",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: docID required",
 		},
 		{
 			name:   "no filename",
+			db:     &DB{},
 			docID:  "foo",
 			status: StatusBadRequest,
 			err:    "kivik: filename required",
@@ -1766,11 +1779,13 @@ func TestGetAttachmentMeta(t *testing.T) { // nolint: gocyclo
 		},
 		{
 			name:   "no doc id",
+			db:     &DB{},
 			status: StatusBadRequest,
 			err:    "kivik: docID required",
 		},
 		{
 			name:   "no filename",
+			db:     &DB{},
 			docID:  "foo",
 			status: StatusBadRequest,
 			err:    "kivik: filename required",

--- a/glide.gopherjs.yaml
+++ b/glide.gopherjs.yaml
@@ -3,7 +3,5 @@ ignore:
 - github.com/gopherjs/gopherjs
 import:
 - package: github.com/gopherjs/jsbuiltin
-- package: github.com/imdario/mergo
-  version: ~0.2.2
 - package: github.com/go-kivik/pouchdb
   version: master

--- a/kivik.go
+++ b/kivik.go
@@ -20,7 +20,10 @@ type Client struct {
 // Options is a collection of options. The keys and values are backend specific.
 type Options map[string]interface{}
 
-func mergeOptions(otherOpts ...Options) (Options, error) {
+func mergeOptions(otherOpts ...Options) Options {
+	if len(otherOpts) == 0 {
+		return nil
+	}
 	options := make(Options)
 	for _, opts := range otherOpts {
 		for k, v := range opts {
@@ -28,9 +31,9 @@ func mergeOptions(otherOpts ...Options) (Options, error) {
 		}
 	}
 	if len(options) == 0 {
-		return nil, nil
+		return nil
 	}
-	return options, nil
+	return options
 }
 
 // New creates a new client object specified by its database driver name
@@ -93,11 +96,7 @@ func (c *Client) Version(ctx context.Context) (*Version, error) {
 // DB returns a handle to the requested database. Any options parameters
 // passed are merged, with later values taking precidence.
 func (c *Client) DB(ctx context.Context, dbName string, options ...Options) (*DB, error) {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
-	db, err := c.driverClient.DB(ctx, dbName, opts)
+	db, err := c.driverClient.DB(ctx, dbName, mergeOptions(options...))
 	return &DB{
 		client:   c,
 		name:     dbName,
@@ -107,29 +106,17 @@ func (c *Client) DB(ctx context.Context, dbName string, options ...Options) (*DB
 
 // AllDBs returns a list of all databases.
 func (c *Client) AllDBs(ctx context.Context, options ...Options) ([]string, error) {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
-	return c.driverClient.AllDBs(ctx, opts)
+	return c.driverClient.AllDBs(ctx, mergeOptions(options...))
 }
 
 // DBExists returns true if the specified database exists.
 func (c *Client) DBExists(ctx context.Context, dbName string, options ...Options) (bool, error) {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return false, err
-	}
-	return c.driverClient.DBExists(ctx, dbName, opts)
+	return c.driverClient.DBExists(ctx, dbName, mergeOptions(options...))
 }
 
 // CreateDB creates a DB of the requested name.
 func (c *Client) CreateDB(ctx context.Context, dbName string, options ...Options) (*DB, error) {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
-	if e := c.driverClient.CreateDB(ctx, dbName, opts); e != nil {
+	if e := c.driverClient.CreateDB(ctx, dbName, mergeOptions(options...)); e != nil {
 		return nil, e
 	}
 	return c.DB(ctx, dbName, nil)
@@ -137,11 +124,7 @@ func (c *Client) CreateDB(ctx context.Context, dbName string, options ...Options
 
 // DestroyDB deletes the requested DB.
 func (c *Client) DestroyDB(ctx context.Context, dbName string, options ...Options) error {
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return err
-	}
-	return c.driverClient.DestroyDB(ctx, dbName, opts)
+	return c.driverClient.DestroyDB(ctx, dbName, mergeOptions(options...))
 }
 
 // Authenticate authenticates the client with the passed authenticator, which

--- a/kivik.go
+++ b/kivik.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/imdario/mergo"
-
 	"github.com/go-kivik/kivik/driver"
 )
 
@@ -23,11 +21,14 @@ type Client struct {
 type Options map[string]interface{}
 
 func mergeOptions(otherOpts ...Options) (Options, error) {
-	var options Options
+	options := make(Options)
 	for _, opts := range otherOpts {
-		if err := mergo.MergeWithOverwrite(&options, opts); err != nil {
-			return nil, err
+		for k, v := range opts {
+			options[k] = v
 		}
+	}
+	if len(options) == 0 {
+		return nil, nil
 	}
 	return options, nil
 }

--- a/kivik_test.go
+++ b/kivik_test.go
@@ -663,7 +663,6 @@ func TestMergeOptions(t *testing.T) {
 	type tst struct {
 		options  []Options
 		expected Options
-		err      string
 	}
 	tests := testy.NewTable()
 	tests.Add("No options", tst{})
@@ -705,8 +704,7 @@ func TestMergeOptions(t *testing.T) {
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
-		result, err := mergeOptions(test.options...)
-		testy.Error(t, test.err, err)
+		result := mergeOptions(test.options...)
 		if d := diff.Interface(test.expected, result); d != nil {
 			t.Error(d)
 		}

--- a/kivik_test.go
+++ b/kivik_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flimzy/diff"
 	"github.com/flimzy/testy"
+
 	"github.com/go-kivik/kivik/driver"
 	"github.com/go-kivik/kivik/mock"
 )
@@ -656,4 +657,58 @@ func TestPing(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeOptions(t *testing.T) {
+	type tst struct {
+		options  []Options
+		expected Options
+		err      string
+	}
+	tests := testy.NewTable()
+	tests.Add("No options", tst{})
+	tests.Add("One set", tst{
+		options: []Options{
+			{"foo": 123},
+		},
+		expected: Options{"foo": 123},
+	})
+	tests.Add("merged", tst{
+		options: []Options{
+			{"foo": 123},
+			{"bar": 321},
+		},
+		expected: Options{
+			"foo": 123,
+			"bar": 321,
+		},
+	})
+	tests.Add("overwrite", tst{
+		options: []Options{
+			{"foo": 123, "bar": 321},
+			{"foo": 111},
+		},
+		expected: Options{
+			"foo": 111,
+			"bar": 321,
+		},
+	})
+	tests.Add("nil option", tst{
+		options: []Options{nil},
+	})
+	tests.Add("different types", tst{
+		options: []Options{
+			{"foo": 123},
+			{"foo": "bar"},
+		},
+		expected: Options{"foo": "bar"},
+	})
+
+	tests.Run(t, func(t *testing.T, test tst) {
+		result, err := mergeOptions(test.options...)
+		testy.Error(t, test.err, err)
+		if d := diff.Interface(test.expected, result); d != nil {
+			t.Error(d)
+		}
+	})
 }

--- a/kivik_test.go
+++ b/kivik_test.go
@@ -199,7 +199,8 @@ func TestDB(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.client.DB(context.Background(), test.dbName, test.options)
+			result := test.client.DB(context.Background(), test.dbName, test.options)
+			err := result.Err()
 			testy.StatusError(t, test.err, test.status, err)
 			if d := diff.Interface(test.expected, result); d != nil {
 				t.Error(d)
@@ -364,7 +365,8 @@ func TestCreateDB(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := test.client.CreateDB(context.Background(), test.dbName, test.opts)
+			db := test.client.CreateDB(context.Background(), test.dbName, test.opts)
+			err := db.Err()
 			testy.StatusError(t, test.err, test.status, err)
 			db.client = nil // Determinism
 			if d := diff.Interface(test.expected, db); d != nil {

--- a/replication.go
+++ b/replication.go
@@ -150,11 +150,7 @@ func (c *Client) GetReplications(ctx context.Context, options ...Options) ([]*Re
 	if !ok {
 		return nil, replicationNotImplemented
 	}
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
-	reps, err := replicator.GetReplications(ctx, opts)
+	reps, err := replicator.GetReplications(ctx, mergeOptions(options...))
 	if err != nil {
 		return nil, err
 	}
@@ -171,11 +167,7 @@ func (c *Client) Replicate(ctx context.Context, targetDSN, sourceDSN string, opt
 	if !ok {
 		return nil, replicationNotImplemented
 	}
-	opts, err := mergeOptions(options...)
-	if err != nil {
-		return nil, err
-	}
-	rep, err := replicator.Replicate(ctx, targetDSN, sourceDSN, opts)
+	rep, err := replicator.Replicate(ctx, targetDSN, sourceDSN, mergeOptions(options...))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To facilitate shorter code, this PR defers errors from the `DB()` and `CreateDB()` calls.  Example usage:

```
db, err := client.DB( ... )
if err != nil {
    return err
}
if _ err = db.Put( ... ); err != nil {
    return err
}
```

Can now be shortened to:

```
db := client.DB( ... )
if _ err = db.Put( ... ); err != nil {
    return err
}
```

or chained:

```
if err := client.DB( ... ).Put( ... ); err != nil {
    return err
}
```

This also simplifies some internal logic, eliminating the need for the `imdario/mergo` dependency.