### PR TITLE
Add Client.Close() and DB.Close() options

### DIFF
--- a/db.go
+++ b/db.go
@@ -625,3 +625,12 @@ func (db *DB) BulkGet(ctx context.Context, docs []BulkDocReference, options ...O
 	}
 	return newRows(ctx, rowsi), nil
 }
+
+// Close cleans up any resources used by the DB. The default CouchDB driver
+// does not use this, the default PouchDB driver does.
+func (db *DB) Close(ctx context.Context) error {
+	if closer, ok := db.driverDB.(driver.DBCloser); ok {
+		return closer.Close(ctx)
+	}
+	return nil
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -383,3 +383,15 @@ type Cluster interface {
 	// ClusterSetup performs the action specified by action.
 	ClusterSetup(ctx context.Context, action interface{}) error
 }
+
+// ClientCloser is an optional interface that may be implemented by a Client
+// to clean up resources when a Client is no longer needed.
+type ClientCloser interface {
+	Close(ctx context.Context) error
+}
+
+// DBCloser is an optional interface that may be implemented by a DB to clean
+// up resources when a DB is no longer needed.
+type DBCloser interface {
+	Close(ctx context.Context) error
+}

--- a/kivik.go
+++ b/kivik.go
@@ -199,3 +199,11 @@ func (c *Client) Ping(ctx context.Context) bool {
 	_, err := c.driverClient.Version(ctx)
 	return err == nil
 }
+
+// Close cleans up any resources used by Client.
+func (c *Client) Close(ctx context.Context) error {
+	if closer, ok := c.driverClient.(driver.ClientCloser); ok {
+		return closer.Close(ctx)
+	}
+	return nil
+}

--- a/mock/client.go
+++ b/mock/client.go
@@ -139,3 +139,16 @@ func (c *Cluster) ClusterStatus(ctx context.Context, options map[string]interfac
 func (c *Cluster) ClusterSetup(ctx context.Context, action interface{}) error {
 	return c.ClusterSetupFunc(ctx, action)
 }
+
+// ClientCloser mocks driver.Client and driver.ClientCloser
+type ClientCloser struct {
+	*Client
+	CloseFunc func(context.Context) error
+}
+
+var _ driver.ClientCloser = &ClientCloser{}
+
+// Close calls c.CloseFunc
+func (c *ClientCloser) Close(ctx context.Context) error {
+	return c.CloseFunc(ctx)
+}

--- a/mock/db.go
+++ b/mock/db.go
@@ -250,3 +250,16 @@ var _ driver.BulkGetter = &BulkGetter{}
 func (db *BulkGetter) BulkGet(ctx context.Context, docs []driver.BulkDocReference, opts map[string]interface{}) (driver.Rows, error) {
 	return db.BulkGetFunc(ctx, docs, opts)
 }
+
+// DBCloser mocks driver.DB and driver.DBCloser
+type DBCloser struct {
+	*DB
+	CloseFunc func(context.Context) error
+}
+
+var _ driver.DBCloser = &DBCloser{}
+
+// Close calls c.CloseFunc
+func (db *DBCloser) Close(ctx context.Context) error {
+	return db.CloseFunc(ctx)
+}


### PR DESCRIPTION
DB.Close() is used by PouchDB.

Client.Close() will likely be used by FS driver and mock driver.