### PR TITLE
Extend the Changes interface to support a "normal" feed.

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -63,7 +63,7 @@ func (c *Changes) ID() string {
 }
 
 // Seq returns the Seq of the current result.
-func (c *Changes) Seq() string {
+func (c *Changes) Seq() SequenceID {
 	return c.curVal.(*driver.Change).Seq
 }
 

--- a/changes.go
+++ b/changes.go
@@ -62,6 +62,11 @@ func (c *Changes) ID() string {
 	return c.curVal.(*driver.Change).ID
 }
 
+// Seq returns the Seq of the current result.
+func (c *Changes) Seq() string {
+	return c.curVal.(*driver.Change).Seq
+}
+
 // ScanDoc works the same as ScanValue, but on the doc field of the result. It
 // is only valid for results that include documents.
 func (c *Changes) ScanDoc(dest interface{}) error {

--- a/changes.go
+++ b/changes.go
@@ -63,7 +63,7 @@ func (c *Changes) ID() string {
 }
 
 // Seq returns the Seq of the current result.
-func (c *Changes) Seq() SequenceID {
+func (c *Changes) Seq() driver.SequenceID {
 	return c.curVal.(*driver.Change).Seq
 }
 

--- a/changes.go
+++ b/changes.go
@@ -67,6 +67,11 @@ func (c *Changes) Seq() driver.SequenceID {
 	return c.curVal.(*driver.Change).Seq
 }
 
+// LastSeq returns the Last Seq of the current result.
+func (c *Changes) LastSeq() driver.SequenceID {
+	return c.changesi.LastSeq()
+}
+
 // ScanDoc works the same as ScanValue, but on the doc field of the result. It
 // is only valid for results that include documents.
 func (c *Changes) ScanDoc(dest interface{}) error {

--- a/changes.go
+++ b/changes.go
@@ -72,6 +72,11 @@ func (c *Changes) LastSeq() driver.SequenceID {
 	return c.changesi.LastSeq()
 }
 
+// Pending returns the Pending rows of the current changes.
+func (c *Changes) Pending() int64 {
+	return c.changesi.Pending()
+}
+
 // ScanDoc works the same as ScanValue, but on the doc field of the result. It
 // is only valid for results that include documents.
 func (c *Changes) ScanDoc(dest interface{}) error {

--- a/driver/changes.go
+++ b/driver/changes.go
@@ -11,6 +11,10 @@ type Changes interface {
 	Next(*Change) error
 	// Close closes the rows iterator.
 	Close() error
+	// LastSeq is the last sequence of the change set.
+	LastSeq() string
+	// Pending is the count of remaining items in the feed.
+	Pending() int64
 }
 
 // Change represents the changes to a single document.

--- a/driver/changes.go
+++ b/driver/changes.go
@@ -12,7 +12,7 @@ type Changes interface {
 	// Close closes the rows iterator.
 	Close() error
 	// LastSeq is the last sequence of the change set.
-	LastSeq() string
+	LastSeq() SequenceID
 	// Pending is the count of remaining items in the feed.
 	Pending() int64
 }

--- a/mock/changes.go
+++ b/mock/changes.go
@@ -24,3 +24,8 @@ func (c *Changes) Close() error {
 func (c *Changes) LastSeq() driver.SequenceID {
 	return ""
 }
+
+// Pending returns the Pending rows of the current changes.
+func (c *Changes) Pending() int64 {
+	return 0
+}

--- a/mock/changes.go
+++ b/mock/changes.go
@@ -19,3 +19,8 @@ func (c *Changes) Next(change *driver.Change) error {
 func (c *Changes) Close() error {
 	return c.CloseFunc()
 }
+
+// LastSeq returns the Last Seq of the current result.
+func (c *Changes) LastSeq() driver.SequenceID {
+	return ""
+}


### PR DESCRIPTION
This extends the Changes interface to support a "normal", paginated changes feed.