### PR TITLE
Remove assumption that Go 1.13 will support all xerrors features, now…

### DIFF
--- a/xerrors.go
+++ b/xerrors.go
@@ -1,5 +1,3 @@
-// +build !1.13
-
 package kivik
 
 import (

--- a/xerrors_13.go
+++ b/xerrors_13.go
@@ -1,7 +1,0 @@
-// +build 1.13
-
-package kivik
-
-type printer = errors.Printer
-
-var formatError = errors.FormatError


### PR DESCRIPTION
… that some are rolled back