### PR TITLE
Zero out the iterator's curVal on each iteration

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -79,6 +79,8 @@ func (i *iter) next() (doClose, ok bool) {
 		return false, false
 	}
 	i.ready = true
+	v := reflect.ValueOf(i.curVal).Elem()
+	v.Set(reflect.Zero(v.Type()))
 	i.lasterr = i.feed.Next(i.curVal)
 	if i.lasterr != nil {
 		return true, false


### PR DESCRIPTION
Go's `json` package doesn't always set all fields when unmarshalling, e.g. a missing field. So not doing this can leak values from a previous iterations to the next.

This is a bit of an hack using `reflect`, it might not work if the interface value is not a pointer type.

Note that I only tested `Changes` so not sure this doesn't break anything else.

Fixes #420