### PR TITLE
Allow use of io.Readers for Doc and Value in iterators

### DIFF
--- a/driver/rows.go
+++ b/driver/rows.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"encoding/json"
+	"io"
 )
 
 // Row is a generic view result row.
@@ -11,11 +12,18 @@ type Row struct {
 	// Key is the view key of the result. For built-in views, this is the same
 	// as ID.
 	Key json.RawMessage `json:"key"`
-	// Value is the raw, un-decoded JSON value. For most built-in views (such as
-	// /_all_docs), this is `{"rev":"X-xxx"}`.
+	// ValueReader is an io.Reader to access the raw, un-decoded JSON value.
+	// For most built-in views, such as /_all_docs, this is `{"rev":"X-xxx"}`.
+	// Takes priority over Value.
+	ValueReader io.Reader `json:"-"`
+	// Value is the raw, un-decoded JSON value.
 	Value json.RawMessage `json:"value"`
-	// Doc is the raw, un-decoded JSON document. This is only populated by views
-	// which return docs, such as /_all_docs?include_docs=true.
+	// DocReader is an io.Reader to access the raw, un-decoded JSON document.
+	// This is only populated by views which return docs, such as
+	// /_all_docs?include_docs=true.
+	// Takes priority over Doc.
+	DocReader io.Reader `json:"-"`
+	// Doc is the raw, un-decoded JSON document.
 	Doc json.RawMessage `json:"doc"`
 	// Error represents the error for any row not fetched. Usually just
 	// 'not_found'.

--- a/rows_test.go
+++ b/rows_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"gitlab.com/flimzy/testy"
@@ -93,7 +94,7 @@ func TestRowsScanValue(t *testing.T) {
 				iter: &iter{
 					ready: true,
 					curVal: &driver.Row{
-						Value: []byte(`{"foo":123.4}`),
+						ValueReader: strings.NewReader(`{"foo":123.4}`),
 					},
 				},
 			},
@@ -144,12 +145,24 @@ func TestRowsScanDoc(t *testing.T) {
 		err      string
 	}{
 		{
-			name: "success",
+			name: "old row",
 			rows: &Rows{
 				iter: &iter{
 					ready: true,
 					curVal: &driver.Row{
 						Doc: []byte(`{"foo":123.4}`),
+					},
+				},
+			},
+			expected: map[string]interface{}{"foo": 123.4},
+		},
+		{
+			name: "success",
+			rows: &Rows{
+				iter: &iter{
+					ready: true,
+					curVal: &driver.Row{
+						DocReader: strings.NewReader(`{"foo":123.4}`),
 					},
 				},
 			},


### PR DESCRIPTION
This won't make much difference for normal CouchDB usage, where each JSON
segment must be parsed in turn.

The immediate reason for this is to allow consolidating the Row and Rows
type for the purpose of https://github.com/go-kivik/kivik/issues/398

This makes it unnecessary to load document into memory, in the case of a simple
single-document Get(), once these types are consolidated.

This may also allow optimizations for other backends in the future, to not
load an entire document into memory before needed.