### PR TITLE
Fix panics when attempting to access uninitialized changes metadata

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -95,6 +95,9 @@ func (c *Changes) Seq() string {
 // read after processing all changes in a change set. Calling Close before
 // enumerating will render this value unreliable.
 func (c *Changes) LastSeq() string {
+	if c.changesi == nil {
+		return ""
+	}
 	return c.changesi.LastSeq()
 }
 
@@ -104,6 +107,9 @@ func (c *Changes) LastSeq() string {
 // changes in a change set. Calling Close before enumerating will render
 // this value unreliable.
 func (c *Changes) Pending() int64 {
+	if c.changesi == nil {
+		return 0
+	}
 	return c.changesi.Pending()
 }
 
@@ -111,5 +117,8 @@ func (c *Changes) Pending() int64 {
 // because this value is returned in the response header (for standard CouchDB
 // operation) anyway, it can be read immediately, before iteration even begins.
 func (c *Changes) ETag() string {
+	if c.changesi == nil {
+		return ""
+	}
 	return c.changesi.ETag()
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -267,3 +267,12 @@ func TestChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestChanges_uninitialized_should_not_panic(t *testing.T) {
+	// These must not panic, because they can be called before iterating
+	// begins.
+	c := &Changes{}
+	_ = c.LastSeq()
+	_ = c.Pending()
+	_ = c.ETag()
+}


### PR DESCRIPTION
Fixes #469 