### PR TITLE
Simplify JSON unmarshaling

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -2,6 +2,7 @@ package kivik
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-kivik/kivik/v4/driver"
 )
@@ -70,7 +71,7 @@ func (c *Changes) ScanDoc(dest interface{}) error {
 		return err
 	}
 	defer runlock()
-	return scan(dest, c.curVal.(*driver.Change).Doc)
+	return json.Unmarshal(c.curVal.(*driver.Change).Doc, dest)
 }
 
 // Changes returns an iterator over the real-time changes feed. The feed remains

--- a/db.go
+++ b/db.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/go-kivik/kivik/v4/driver"
@@ -133,14 +132,8 @@ func (r *Row) ScanDoc(dest interface{}) error {
 	if r.Err != nil {
 		return r.Err
 	}
-	if reflect.TypeOf(dest).Kind() != reflect.Ptr {
-		return errNonPtr
-	}
 	defer r.Body.Close() // nolint: errcheck
-	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
-		return err
-	}
-	return nil
+	return json.NewDecoder(r.Body).Decode(dest)
 }
 
 // Get fetches the requested document. Any errors are deferred until the

--- a/db_test.go
+++ b/db_test.go
@@ -1229,8 +1229,8 @@ func TestRowScanDoc(t *testing.T) {
 			name:   "non-pointer dst",
 			row:    &Row{Body: body(`{"foo":123.4}`)},
 			dst:    map[string]interface{}{},
-			status: http.StatusBadRequest,
-			err:    "kivik: destination is not a pointer",
+			status: http.StatusInternalServerError,
+			err:    "json: Unmarshal(non-pointer map[string]interface {})",
 		},
 		{
 			name:   "invalid json",

--- a/iterator.go
+++ b/iterator.go
@@ -2,10 +2,8 @@ package kivik
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
-	"reflect"
 	"sync"
 
 	"github.com/go-kivik/kivik/v4/driver"
@@ -142,30 +140,4 @@ func (i *iter) Err() error {
 		return nil
 	}
 	return i.lasterr
-}
-
-func scan(dest interface{}, val json.RawMessage) error {
-	if reflect.TypeOf(dest).Kind() != reflect.Ptr {
-		return errNonPtr
-	}
-	switch d := dest.(type) {
-	case *[]byte:
-		if d == nil {
-			return errNilPtr
-		}
-		tgt := make([]byte, len(val))
-		copy(tgt, val)
-		*d = tgt
-		return nil
-	case *json.RawMessage:
-		if d == nil {
-			return errNilPtr
-		}
-		*d = val
-		return nil
-	}
-	if err := json.Unmarshal(val, dest); err != nil {
-		return err
-	}
-	return nil
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2,10 +2,8 @@ package kivik
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"testing"
 	"time"
 
@@ -62,95 +60,6 @@ func TestCancelledIterator(t *testing.T) {
 	}
 	if err := iter.Err(); err.Error() != "context deadline exceeded" {
 		t.Errorf("Unexpected error: %s", err)
-	}
-}
-
-func TestIteratorScan(t *testing.T) {
-	type Test struct {
-		name     string
-		dst      interface{}
-		input    json.RawMessage
-		expected interface{}
-		status   int
-		err      string
-	}
-	tests := []Test{
-		{
-			name:   "non-pointer",
-			dst:    map[string]string{},
-			input:  []byte(`{"foo":123.4}`),
-			status: http.StatusBadRequest,
-			err:    "kivik: destination is not a pointer",
-		},
-		func() Test {
-			dst := map[string]interface{}{}
-			expected := map[string]interface{}{"foo": 123.4}
-			return Test{
-				name:     "standard unmarshal",
-				dst:      &dst,
-				input:    []byte(`{"foo":123.4}`),
-				expected: &expected,
-			}
-		}(),
-		func() Test {
-			dst := map[string]interface{}{}
-			return Test{
-				name:   "invalid JSON",
-				dst:    &dst,
-				input:  []byte(`invalid JSON`),
-				status: http.StatusInternalServerError,
-				err:    "invalid character 'i' looking for beginning of value",
-			}
-		}(),
-		func() Test {
-			var dst *json.RawMessage
-			return Test{
-				name:   "nil *json.RawMessage",
-				dst:    dst,
-				input:  []byte(`{"foo":123.4}`),
-				status: http.StatusBadRequest,
-				err:    "kivik: destination pointer is nil",
-			}
-		}(),
-		func() Test {
-			var dst *[]byte
-			return Test{
-				name:   "nil *[]byte",
-				dst:    dst,
-				input:  []byte(`{"foo":123.4}`),
-				status: http.StatusBadRequest,
-				err:    "kivik: destination pointer is nil",
-			}
-		}(),
-		func() Test {
-			dst := []byte{}
-			expected := []byte(`{"foo":123.4}`)
-			return Test{
-				name:     "[]byte",
-				dst:      &dst,
-				input:    []byte(`{"foo":123.4}`),
-				expected: &expected,
-			}
-		}(),
-		func() Test {
-			dst := json.RawMessage{}
-			expected := json.RawMessage(`{"foo":123.4}`)
-			return Test{
-				name:     "json.RawMessage",
-				dst:      &dst,
-				input:    []byte(`{"foo":123.4}`),
-				expected: &expected,
-			}
-		}(),
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := scan(test.dst, test.input)
-			testy.StatusError(t, test.err, test.status, err)
-			if d := testy.DiffInterface(test.expected, test.dst); d != nil {
-				t.Error(d)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Instead of special casing *[]byte and *json.RawMessage, and some silly
cusotm error messages, why not simplify and use the standard marshaler?

This is, of course, a breaking change, so not eligible for v3.