### PR TITLE
Reduce marshal/remarshal cycles

### DIFF
--- a/db.go
+++ b/db.go
@@ -213,7 +213,7 @@ func normalizeFromJSON(i interface{}) (interface{}, error) {
 	case []byte:
 		body = t
 	case json.RawMessage:
-		body = t
+		return t, nil
 	default:
 		r, ok := i.(io.Reader)
 		if !ok {

--- a/db.go
+++ b/db.go
@@ -210,10 +210,10 @@ func (db *DB) CreateDoc(ctx context.Context, doc interface{}, options ...Options
 func normalizeFromJSON(i interface{}) (interface{}, error) {
 	var body []byte
 	switch t := i.(type) {
+	case json.Marshaler:
+		return t, nil
 	case []byte:
 		body = t
-	case json.RawMessage:
-		return t, nil
 	default:
 		r, ok := i.(io.Reader)
 		if !ok {

--- a/db.go
+++ b/db.go
@@ -214,16 +214,14 @@ func normalizeFromJSON(i interface{}) (interface{}, error) {
 		return t, nil
 	case []byte:
 		body = t
-	default:
-		r, ok := i.(io.Reader)
-		if !ok {
-			return i, nil
-		}
-		var err error
-		body, err = ioutil.ReadAll(r)
+	case io.Reader:
+		body, err := ioutil.ReadAll(t)
 		if err != nil {
 			return nil, &Error{HTTPStatus: http.StatusBadRequest, Err: err}
 		}
+		return json.RawMessage(body), nil
+	default:
+		return i, nil
 	}
 	var x map[string]interface{}
 	if err := json.Unmarshal(body, &x); err != nil {

--- a/db.go
+++ b/db.go
@@ -208,12 +208,9 @@ func (db *DB) CreateDoc(ctx context.Context, doc interface{}, options ...Options
 // normalizeFromJSON unmarshals a []byte, json.RawMessage or io.Reader to a
 // map[string]interface{}, or passed through any other types.
 func normalizeFromJSON(i interface{}) (interface{}, error) {
-	var body []byte
 	switch t := i.(type) {
 	case json.Marshaler:
 		return t, nil
-	case []byte:
-		body = t
 	case io.Reader:
 		body, err := ioutil.ReadAll(t)
 		if err != nil {
@@ -223,11 +220,6 @@ func normalizeFromJSON(i interface{}) (interface{}, error) {
 	default:
 		return i, nil
 	}
-	var x map[string]interface{}
-	if err := json.Unmarshal(body, &x); err != nil {
-		return nil, &Error{HTTPStatus: http.StatusBadRequest, Err: err}
-	}
-	return x, nil
 }
 
 func extractDocID(i interface{}) (string, bool) {

--- a/db_test.go
+++ b/db_test.go
@@ -1042,7 +1042,7 @@ func TestNormalizeFromJSON(t *testing.T) {
 			t.Run(test.Name, func(t *testing.T) {
 				result, err := normalizeFromJSON(test.Input)
 				testy.StatusError(t, test.Error, test.Status, err)
-				if d := testy.DiffInterface(test.Expected, result); d != nil {
+				if d := testy.DiffAsJSON(test.Expected, result); d != nil {
 					t.Error(d)
 				}
 			})
@@ -1057,7 +1057,7 @@ func TestPut(t *testing.T) {
 		if expectedDocID != docID {
 			return "", fmt.Errorf("Unexpected docID: %s", docID)
 		}
-		if d := testy.DiffInterface(expectedDoc, doc); d != nil {
+		if d := testy.DiffAsJSON(expectedDoc, doc); d != nil {
 			return "", fmt.Errorf("Unexpected doc: %s", d)
 		}
 		if d := testy.DiffInterface(testOptions, opts); d != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -1010,17 +1010,6 @@ func TestNormalizeFromJSON(t *testing.T) {
 			Expected: int(5),
 		},
 		{
-			Name:   "InvalidJSON",
-			Input:  []byte(`invalid`),
-			Status: http.StatusBadRequest,
-			Error:  "invalid character 'i' looking for beginning of value",
-		},
-		{
-			Name:     "Bytes",
-			Input:    []byte(`{"foo":"bar"}`),
-			Expected: map[string]interface{}{"foo": "bar"},
-		},
-		{
 			Name:     "RawMessage",
 			Input:    json.RawMessage(`{"foo":"bar"}`),
 			Expected: map[string]interface{}{"foo": "bar"},
@@ -1108,12 +1097,16 @@ func TestPut(t *testing.T) {
 			newRev:  "1-xxx",
 		},
 		{
-			name:   "InvalidJSON",
-			db:     &DB{},
+			name: "InvalidJSON",
+			db: &DB{
+				driverDB: &mock.DB{
+					PutFunc: putFunc,
+				},
+			},
 			docID:  "foo",
-			input:  []byte("Something bogus"),
-			status: http.StatusBadRequest,
-			err:    "invalid character 'S' looking for beginning of value",
+			input:  json.RawMessage("Something bogus"),
+			status: http.StatusInternalServerError,
+			err:    "Unexpected doc: failed to marshal actual value: invalid character 'S' looking for beginning of value",
 		},
 		{
 			name: "Bytes",


### PR DESCRIPTION
Simplify the handling of various types of doc input, to reduce the unmarshal/re-marshal cycles.  Also, drops support for `[]byte` documents--use a `json.RawMessage` instead.