### PR TITLE
Allow rev in options for DeleteAttachment()

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ variables:
 
 linter:
     stage: test
-    image: golangci/golangci-lint:v1.30
+    image: golangci/golangci-lint:v1.33
     script:
         - go mod download
         - golangci-lint run ./...
@@ -49,7 +49,7 @@ go-1.14:
     <<: *test_template
     image: golang:1.14
 
-go-1.14:
+go-1.15:
     <<: *test_template
     image: golang:1.15
 

--- a/db.go
+++ b/db.go
@@ -560,7 +560,8 @@ func (db *DB) GetAttachmentMeta(ctx context.Context, docID, filename string, opt
 }
 
 // DeleteAttachment deletes an attachment from a document, returning the
-// document's new revision.
+// document's new revision. The revision may be provided via options, which
+// takes priority over the rev argument.
 func (db *DB) DeleteAttachment(ctx context.Context, docID, rev, filename string, options ...Options) (newRev string, err error) {
 	if db.err != nil {
 		return "", db.err
@@ -571,7 +572,11 @@ func (db *DB) DeleteAttachment(ctx context.Context, docID, rev, filename string,
 	if filename == "" {
 		return "", missingArg("filename")
 	}
-	return db.driverDB.DeleteAttachment(ctx, docID, rev, filename, mergeOptions(options...))
+	opts := mergeOptions(options...)
+	if rv, ok := opts["rev"].(string); ok && rv != "" {
+		rev = rv
+	}
+	return db.driverDB.DeleteAttachment(ctx, docID, rev, filename, opts)
 }
 
 // PurgeResult is the result of a purge request.

--- a/db_test.go
+++ b/db_test.go
@@ -1550,6 +1550,35 @@ func TestDeleteAttachment(t *testing.T) {
 			err:    "db error",
 		},
 		{
+			name:     "rev in options",
+			docID:    "foo",
+			filename: "foo.txt",
+			options:  map[string]interface{}{"rev": "1-xxx"},
+			db: &DB{
+				driverDB: &mock.DB{
+					DeleteAttachmentFunc: func(_ context.Context, docID, rev, filename string, opts map[string]interface{}) (string, error) {
+						expectedDocID := "foo"
+						expectedRev := "1-xxx"
+						expectedFilename := "foo.txt"
+						if docID != expectedDocID {
+							return "", fmt.Errorf("Unexpected docID: %s", docID)
+						}
+						if rev != expectedRev {
+							return "", fmt.Errorf("Unexpected rev: %s", rev)
+						}
+						if filename != expectedFilename {
+							return "", fmt.Errorf("Unexpected filename: %s", filename)
+						}
+						if d := testy.DiffInterface(map[string]interface{}{"rev": "1-xxx"}, opts); d != nil {
+							return "", fmt.Errorf("Unexpected options:\n%s", d)
+						}
+						return "2-xxx", nil
+					},
+				},
+			},
+			newRev: "2-xxx",
+		},
+		{
 			name: "success",
 			db: &DB{
 				driverDB: &mock.DB{


### PR DESCRIPTION
Same as #518, but for DeleteAttachment()