### PR TITLE
Forward errors from any methods that return a *Rows object

### DIFF
--- a/db.go
+++ b/db.go
@@ -79,19 +79,19 @@ func (db *DB) DesignDocs(ctx context.Context, options ...Options) *Rows {
 }
 
 // LocalDocs returns a list of all documents in the database.
-func (db *DB) LocalDocs(ctx context.Context, options ...Options) (*Rows, error) {
+func (db *DB) LocalDocs(ctx context.Context, options ...Options) *Rows {
 	if db.err != nil {
-		return nil, db.err
+		return &Rows{err: db.err}
 	}
 	ldocer, ok := db.driverDB.(driver.LocalDocer)
 	if !ok {
-		return nil, &Error{HTTPStatus: http.StatusNotImplemented, Err: errors.New("kivik: local doc view not supported by driver")}
+		return &Rows{err: &Error{HTTPStatus: http.StatusNotImplemented, Err: errors.New("kivik: local doc view not supported by driver")}}
 	}
 	rowsi, err := ldocer.LocalDocs(ctx, mergeOptions(options...))
 	if err != nil {
-		return nil, err
+		return &Rows{err: err}
 	}
-	return newRows(ctx, rowsi), nil
+	return newRows(ctx, rowsi)
 }
 
 // Query executes the specified view function from the specified design

--- a/db.go
+++ b/db.go
@@ -51,15 +51,15 @@ func (db *DB) Err() error {
 }
 
 // AllDocs returns a list of all documents in the database.
-func (db *DB) AllDocs(ctx context.Context, options ...Options) (*Rows, error) {
+func (db *DB) AllDocs(ctx context.Context, options ...Options) *Rows {
 	if db.err != nil {
-		return nil, db.err
+		return &Rows{err: db.err}
 	}
 	rowsi, err := db.driverDB.AllDocs(ctx, mergeOptions(options...))
 	if err != nil {
-		return nil, err
+		return &Rows{err: err}
 	}
-	return newRows(ctx, rowsi), nil
+	return newRows(ctx, rowsi)
 }
 
 // DesignDocs returns a list of all documents in the database.

--- a/db.go
+++ b/db.go
@@ -628,13 +628,13 @@ type BulkGetReference struct {
 // or for getting revision history.
 //
 // See http://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-get
-func (db *DB) BulkGet(ctx context.Context, docs []BulkGetReference, options ...Options) (*Rows, error) {
+func (db *DB) BulkGet(ctx context.Context, docs []BulkGetReference, options ...Options) *Rows {
 	if db.err != nil {
-		return nil, db.err
+		return &Rows{err: db.err}
 	}
 	bulkGetter, ok := db.driverDB.(driver.BulkGetter)
 	if !ok {
-		return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "kivik: bulk get not supported by driver"}
+		return &Rows{err: &Error{HTTPStatus: http.StatusNotImplemented, Message: "kivik: bulk get not supported by driver"}}
 	}
 	refs := make([]driver.BulkGetReference, len(docs))
 	for i, ref := range docs {
@@ -642,9 +642,9 @@ func (db *DB) BulkGet(ctx context.Context, docs []BulkGetReference, options ...O
 	}
 	rowsi, err := bulkGetter.BulkGet(ctx, refs, mergeOptions(options...))
 	if err != nil {
-		return nil, err
+		return &Rows{err: err}
 	}
-	return newRows(ctx, rowsi), nil
+	return newRows(ctx, rowsi)
 }
 
 // Close cleans up any resources used by the DB. The default CouchDB driver

--- a/db.go
+++ b/db.go
@@ -63,19 +63,19 @@ func (db *DB) AllDocs(ctx context.Context, options ...Options) *Rows {
 }
 
 // DesignDocs returns a list of all documents in the database.
-func (db *DB) DesignDocs(ctx context.Context, options ...Options) (*Rows, error) {
+func (db *DB) DesignDocs(ctx context.Context, options ...Options) *Rows {
 	if db.err != nil {
-		return nil, db.err
+		return &Rows{err: db.err}
 	}
 	ddocer, ok := db.driverDB.(driver.DesignDocer)
 	if !ok {
-		return nil, &Error{HTTPStatus: http.StatusNotImplemented, Err: errors.New("kivik: design doc view not supported by driver")}
+		return &Rows{err: &Error{HTTPStatus: http.StatusNotImplemented, Err: errors.New("kivik: design doc view not supported by driver")}}
 	}
 	rowsi, err := ddocer.DesignDocs(ctx, mergeOptions(options...))
 	if err != nil {
-		return nil, err
+		return &Rows{err: err}
 	}
-	return newRows(ctx, rowsi), nil
+	return newRows(ctx, rowsi)
 }
 
 // LocalDocs returns a list of all documents in the database.

--- a/db.go
+++ b/db.go
@@ -684,18 +684,18 @@ type Diffs map[string]RevDiff
 //     }
 //
 // See http://docs.couchdb.org/en/stable/api/database/misc.html#db-revs-diff
-func (db *DB) RevsDiff(ctx context.Context, revMap interface{}) (*Rows, error) {
+func (db *DB) RevsDiff(ctx context.Context, revMap interface{}) *Rows {
 	if db.err != nil {
-		return nil, db.err
+		return &Rows{err: db.err}
 	}
 	if rd, ok := db.driverDB.(driver.RevsDiffer); ok {
 		rowsi, err := rd.RevsDiff(ctx, revMap)
 		if err != nil {
-			return nil, err
+			return &Rows{err: err}
 		}
-		return newRows(ctx, rowsi), nil
+		return newRows(ctx, rowsi)
 	}
-	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "kivik: _revs_diff not supported by driver"}
+	return &Rows{err: &Error{HTTPStatus: http.StatusNotImplemented, Message: "kivik: _revs_diff not supported by driver"}}
 }
 
 // PartitionStats contains partition statistics.

--- a/db.go
+++ b/db.go
@@ -97,17 +97,17 @@ func (db *DB) LocalDocs(ctx context.Context, options ...Options) (*Rows, error) 
 // Query executes the specified view function from the specified design
 // document. ddoc and view may or may not be be prefixed with '_design/'
 // and '_view/' respectively.
-func (db *DB) Query(ctx context.Context, ddoc, view string, options ...Options) (*Rows, error) {
+func (db *DB) Query(ctx context.Context, ddoc, view string, options ...Options) *Rows {
 	if db.err != nil {
-		return nil, db.err
+		return &Rows{err: db.err}
 	}
 	ddoc = strings.TrimPrefix(ddoc, "_design/")
 	view = strings.TrimPrefix(view, "_view/")
 	rowsi, err := db.driverDB.Query(ctx, ddoc, view, mergeOptions(options...))
 	if err != nil {
-		return nil, err
+		return &Rows{err: err}
 	}
-	return newRows(ctx, rowsi), nil
+	return newRows(ctx, rowsi)
 }
 
 // Row contains the result of calling Get for a single document. For most uses,

--- a/db_example_test.go
+++ b/db_example_test.go
@@ -103,11 +103,11 @@ func ExampleDB_updateView() {
 }
 
 func ExampleDB_query() {
-	rows, err := db.Query(context.TODO(), "_design/foo", "_view/bar", kivik.Options{
+	rows := db.Query(context.TODO(), "_design/foo", "_view/bar", kivik.Options{
 		"startkey": `"foo"`,                           // Quotes are necessary so the
 		"endkey":   `"foo` + kivik.EndKeySuffix + `"`, // key is a valid JSON object
 	})
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		panic(err)
 	}
 	for rows.Next() {
@@ -126,8 +126,8 @@ func ExampleDB_mapReduce() {
 	opts := kivik.Options{
 		"group": true,
 	}
-	rows, err := db.Query(context.TODO(), "_design/foo", "_view/bar", opts)
-	if err != nil {
+	rows := db.Query(context.TODO(), "_design/foo", "_view/bar", opts)
+	if err := rows.Err(); err != nil {
 		panic(err)
 	}
 	for rows.Next() {

--- a/db_test.go
+++ b/db_test.go
@@ -94,10 +94,10 @@ func TestAllDocs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.db.AllDocs(context.Background(), test.options)
-			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := testy.DiffInterface(test.expected, result); d != nil {
+			rows := test.db.AllDocs(context.Background(), test.options)
+			testy.StatusError(t, test.err, test.status, rows.Err())
+			rows.cancel = nil // Determinism
+			if d := testy.DiffInterface(test.expected, rows); d != nil {
 				t.Error(d)
 			}
 		})

--- a/db_test.go
+++ b/db_test.go
@@ -2060,8 +2060,8 @@ func TestRevsDiff(t *testing.T) {
 	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
-		rows, err := tt.db.RevsDiff(context.Background(), tt.revMap)
-		testy.StatusError(t, tt.err, tt.status, err)
+		rows := tt.db.RevsDiff(context.Background(), tt.revMap)
+		testy.StatusError(t, tt.err, tt.status, rows.Err())
 		rows.cancel = nil // Determinism
 		if d := testy.DiffInterface(tt.expected, rows); d != nil {
 			t.Error(d)

--- a/db_test.go
+++ b/db_test.go
@@ -288,10 +288,10 @@ func TestQuery(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.db.Query(context.Background(), test.ddoc, test.view, test.options)
-			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := testy.DiffInterface(test.expected, result); d != nil {
+			rows := test.db.Query(context.Background(), test.ddoc, test.view, test.options)
+			testy.StatusError(t, test.err, test.status, rows.Err())
+			rows.cancel = nil // Determinism
+			if d := testy.DiffInterface(test.expected, rows); d != nil {
 				t.Error(d)
 			}
 		})

--- a/db_test.go
+++ b/db_test.go
@@ -220,10 +220,10 @@ func TestLocalDocs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.db.LocalDocs(context.Background(), test.options)
-			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := testy.DiffInterface(test.expected, result); d != nil {
+			rows := test.db.LocalDocs(context.Background(), test.options)
+			testy.StatusError(t, test.err, test.status, rows.Err())
+			rows.cancel = nil // Determinism
+			if d := testy.DiffInterface(test.expected, rows); d != nil {
 				t.Error(d)
 			}
 		})

--- a/db_test.go
+++ b/db_test.go
@@ -157,10 +157,10 @@ func TestDesignDocs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.db.DesignDocs(context.Background(), test.options)
-			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := testy.DiffInterface(test.expected, result); d != nil {
+			rows := test.db.DesignDocs(context.Background(), test.options)
+			testy.StatusError(t, test.err, test.status, rows.Err())
+			rows.cancel = nil // Determinism
+			if d := testy.DiffInterface(test.expected, rows); d != nil {
 				t.Error(d)
 			}
 		})

--- a/db_test.go
+++ b/db_test.go
@@ -1978,10 +1978,10 @@ func TestBulkGet(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.db.BulkGet(context.Background(), test.docs, test.options)
-			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := testy.DiffInterface(test.expected, result); d != nil {
+			rows := test.db.BulkGet(context.Background(), test.docs, test.options)
+			testy.StatusError(t, test.err, test.status, rows.Err())
+			rows.cancel = nil // Determinism
+			if d := testy.DiffInterface(test.expected, rows); d != nil {
 				t.Error(d)
 			}
 		})

--- a/find.go
+++ b/find.go
@@ -25,6 +25,9 @@ var findNotImplemented = &Error{HTTPStatus: http.StatusNotImplemented, Message: 
 // JSON-marshalable to a valid query.
 // See http://docs.couchdb.org/en/2.0.0/api/database/find.html#db-find
 func (db *DB) Find(ctx context.Context, query interface{}, options ...Options) *Rows {
+	if db.err != nil {
+		return &Rows{err: db.err}
+	}
 	if finder, ok := db.driverDB.(driver.OptsFinder); ok {
 		rowsi, err := finder.Find(ctx, query, mergeOptions(options...))
 		if err != nil {

--- a/find.go
+++ b/find.go
@@ -24,23 +24,23 @@ var findNotImplemented = &Error{HTTPStatus: http.StatusNotImplemented, Message: 
 // Find executes a query using the new /_find interface. The query must be
 // JSON-marshalable to a valid query.
 // See http://docs.couchdb.org/en/2.0.0/api/database/find.html#db-find
-func (db *DB) Find(ctx context.Context, query interface{}, options ...Options) (*Rows, error) {
+func (db *DB) Find(ctx context.Context, query interface{}, options ...Options) *Rows {
 	if finder, ok := db.driverDB.(driver.OptsFinder); ok {
 		rowsi, err := finder.Find(ctx, query, mergeOptions(options...))
 		if err != nil {
-			return nil, err
+			return &Rows{err: err}
 		}
-		return newRows(ctx, rowsi), nil
+		return newRows(ctx, rowsi)
 	}
 	// nolint:staticcheck
 	if finder, ok := db.driverDB.(driver.Finder); ok {
 		rowsi, err := finder.Find(ctx, query)
 		if err != nil {
-			return nil, err
+			return &Rows{err: err}
 		}
-		return newRows(ctx, rowsi), nil
+		return newRows(ctx, rowsi)
 	}
-	return nil, findNotImplemented
+	return &Rows{err: findNotImplemented}
 }
 
 // CreateIndex creates an index if it doesn't already exist. ddoc and name may

--- a/find_test.go
+++ b/find_test.go
@@ -118,10 +118,10 @@ func TestFind(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := test.db.Find(context.Background(), test.query)
-			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
-			if d := testy.DiffInterface(test.expected, result); d != nil {
+			rows := test.db.Find(context.Background(), test.query)
+			testy.StatusError(t, test.err, test.status, rows.Err())
+			rows.cancel = nil // Determinism
+			if d := testy.DiffInterface(test.expected, rows); d != nil {
 				t.Error(d)
 			}
 		})

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -82,7 +82,7 @@ func ExampleRows_eOQ() {
 	}
 	ctx := context.TODO()
 	// Kivik adaptation of example found at https://docs.couchdb.org/en/stable/api/ddoc/views.html#sending-multiple-queries-to-a-view
-	rows, err := client.DB("foo").Query(ctx, "recipes", "by_title", Options{
+	rows := client.DB("foo").Query(ctx, "recipes", "by_title", Options{
 		"queries": []map[string]interface{}{
 			{
 				"keys": []string{"meatballs", "spaghetti"},
@@ -93,7 +93,7 @@ func ExampleRows_eOQ() {
 			},
 		},
 	})
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		panic(err)
 	}
 	for rows.Next() {

--- a/rows.go
+++ b/rows.go
@@ -136,6 +136,9 @@ func (r *Rows) ScanAllDocs(dest interface{}) (err error) {
 			err = closeErr
 		}
 	}()
+	if r.err != nil {
+		return r.err
+	}
 
 	value := reflect.ValueOf(dest)
 	if value.Kind() != reflect.Ptr {

--- a/rows.go
+++ b/rows.go
@@ -26,6 +26,7 @@ import (
 type Rows struct {
 	*iter
 	rowsi driver.Rows
+	err   error
 }
 
 // Next prepares the next result value for reading. It returns true on success
@@ -38,6 +39,9 @@ func (r *Rows) Next() bool {
 // Err returns the error, if any, that was encountered during iteration. Err may
 // be called after an explicit or implicit Close.
 func (r *Rows) Err() error {
+	if r.err != nil {
+		return r.err
+	}
 	return r.iter.Err()
 }
 
@@ -76,6 +80,9 @@ func newRows(ctx context.Context, rowsi driver.Rows) *Rows {
 // For all other types, refer to the documentation for json.Unmarshal for type
 // conversion rules.
 func (r *Rows) ScanValue(dest interface{}) error {
+	if r.err != nil {
+		return r.err
+	}
 	runlock, err := r.rlock()
 	if err != nil {
 		return err
@@ -94,6 +101,9 @@ func (r *Rows) ScanValue(dest interface{}) error {
 // ScanDoc works the same as ScanValue, but on the doc field of the result. It
 // will return an error if the query does not include documents.
 func (r *Rows) ScanDoc(dest interface{}) error {
+	if r.err != nil {
+		return r.err
+	}
 	runlock, err := r.rlock()
 	if err != nil {
 		return err
@@ -173,6 +183,9 @@ func (r *Rows) ScanAllDocs(dest interface{}) (err error) {
 // ScanKey works the same as ScanValue, but on the key field of the result. For
 // simple keys, which are just strings, the Key() method may be easier to use.
 func (r *Rows) ScanKey(dest interface{}) error {
+	if r.err != nil {
+		return r.err
+	}
 	runlock, err := r.rlock()
 	if err != nil {
 		return err


### PR DESCRIPTION
Relates to #398.

As a step toward unifying `*Rows` with `*Row`, this PR modifies all methods that return a `*Rows` value (i.e. `Query()`, `AllDocs()`, `Find()`, etc), to forward the error to the first call to `ScanDoc()` or related.