### PR TITLE
Work toward integrating *Row into Rows

### DIFF
--- a/db.go
+++ b/db.go
@@ -110,33 +110,6 @@ func (db *DB) Query(ctx context.Context, ddoc, view string, options ...Options) 
 	return newRows(ctx, rowsi)
 }
 
-// Row contains the result of calling Get for a single document. For most uses,
-// it is sufficient just to call the ScanDoc method. For more advanced uses, the
-// fields may be accessed directly.
-type Row struct {
-	// ContentLength records the size of the JSON representation of the document
-	// as requestd. The value -1 indicates that the length is unknown. Values
-	// >= 0 indicate that the given number of bytes may be read from Body.
-	ContentLength int64
-
-	// Rev is the revision ID of the returned document.
-	Rev string
-
-	// Body represents the document's content.
-	//
-	// Kivik will always return a non-nil Body, except when Err is non-nil. The
-	// ScanDoc method will close Body. When not using ScanDoc, it is the
-	// caller's responsibility to close Body
-	Body io.ReadCloser
-
-	// Err contains any error that occurred while fetching the document. It is
-	// typically returned by ScanDoc.
-	Err error
-
-	// Attachments is experimental
-	Attachments *AttachmentsIterator
-}
-
 // ScanDoc unmarshals the data from the fetched row into dest. It is an
 // intelligent wrapper around json.Unmarshal which also handles
 // multipart/related responses. When done, the underlying reader is closed.

--- a/db.go
+++ b/db.go
@@ -110,17 +110,6 @@ func (db *DB) Query(ctx context.Context, ddoc, view string, options ...Options) 
 	return newRows(ctx, rowsi)
 }
 
-// ScanDoc unmarshals the data from the fetched row into dest. It is an
-// intelligent wrapper around json.Unmarshal which also handles
-// multipart/related responses. When done, the underlying reader is closed.
-func (r *Row) ScanDoc(dest interface{}) error {
-	if r.Err != nil {
-		return r.Err
-	}
-	defer r.Body.Close() // nolint: errcheck
-	return json.NewDecoder(r.Body).Decode(dest)
-}
-
 // Get fetches the requested document. Any errors are deferred until the
 // row.ScanDoc call.
 func (db *DB) Get(ctx context.Context, docID string, options ...Options) *Row {

--- a/iterator.go
+++ b/iterator.go
@@ -50,7 +50,7 @@ func (i *iter) rlock() (unlock func(), err error) {
 		i.mu.RUnlock()
 		return nil, &Error{HTTPStatus: http.StatusBadRequest, Message: "kivik: Iterator access before calling Next"}
 	}
-	return func() { i.mu.RUnlock() }, nil
+	return i.mu.RUnlock, nil
 }
 
 // newIterator instantiates a new iterator.

--- a/iterator.go
+++ b/iterator.go
@@ -53,6 +53,15 @@ func (i *iter) rlock() (unlock func(), err error) {
 	return i.mu.RUnlock, nil
 }
 
+func (i *iter) isReady() (unlock func(), err error) {
+	i.mu.RLock()
+	if !i.ready {
+		i.mu.RUnlock()
+		return nil, &Error{HTTPStatus: http.StatusBadRequest, Message: "kivik: Iterator access before calling Next"}
+	}
+	return i.mu.RUnlock, nil
+}
+
 // newIterator instantiates a new iterator.
 //
 // ctx is a possibly-cancellable context

--- a/row.go
+++ b/row.go
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package kivik
+
+import "io"
+
+// Row contains the result of calling Get for a single document. For most uses,
+// it is sufficient just to call the ScanDoc method. For more advanced uses, the
+// fields may be accessed directly.
+type Row struct {
+	// ContentLength records the size of the JSON representation of the document
+	// as requestd. The value -1 indicates that the length is unknown. Values
+	// >= 0 indicate that the given number of bytes may be read from Body.
+	ContentLength int64
+
+	// Rev is the revision ID of the returned document.
+	Rev string
+
+	// Body represents the document's content.
+	//
+	// Kivik will always return a non-nil Body, except when Err is non-nil. The
+	// ScanDoc method will close Body. When not using ScanDoc, it is the
+	// caller's responsibility to close Body
+	Body io.ReadCloser
+
+	// Err contains any error that occurred while fetching the document. It is
+	// typically returned by ScanDoc.
+	Err error
+
+	// Attachments is experimental
+	Attachments *AttachmentsIterator
+}


### PR DESCRIPTION
- Add a new `*row` type (still unused) that wraps `*Row`, but satifies the `Rows` interface
- Tweaked behavior of `Rows` methods to work on the last item in the iterator, even after close.