### PR TITLE
Move EOQ() method from *iter to *Rows, so it's not promoted on all iterators

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -28,12 +28,6 @@ func (r *BulkResults) Err() error {
 	return r.iter.Err()
 }
 
-// Close closes the feed. Any unread updates will still be accessible via
-// Next().
-func (r *BulkResults) Close() error {
-	return r.iter.Close()
-}
-
 type bulkIterator struct{ driver.BulkResults }
 
 var _ iterator = &bulkIterator{}

--- a/bulk.go
+++ b/bulk.go
@@ -15,13 +15,6 @@ type BulkResults struct {
 	bulki driver.BulkResults
 }
 
-// Next returns the next BulkResult from the feed. If an error occurs, it will
-// be returned and the feed closed. io.EOF will be returned when there are no
-// more results.
-func (r *BulkResults) Next() bool {
-	return r.iter.Next()
-}
-
 type bulkIterator struct{ driver.BulkResults }
 
 var _ iterator = &bulkIterator{}

--- a/bulk.go
+++ b/bulk.go
@@ -22,12 +22,6 @@ func (r *BulkResults) Next() bool {
 	return r.iter.Next()
 }
 
-// Err returns the error, if any, that was encountered during iteration. Err
-// may be called after an explicit or implicit Close.
-func (r *BulkResults) Err() error {
-	return r.iter.Err()
-}
-
 type bulkIterator struct{ driver.BulkResults }
 
 var _ iterator = &bulkIterator{}

--- a/changes.go
+++ b/changes.go
@@ -19,12 +19,6 @@ func (c *Changes) Next() bool {
 	return c.iter.Next()
 }
 
-// Err returns the error, if any, that was encountered during iteration. Err may
-// be called after an explicit or implicit Close.
-func (c *Changes) Err() error {
-	return c.iter.Err()
-}
-
 type changesIterator struct{ driver.Changes }
 
 var _ iterator = &changesIterator{}

--- a/changes.go
+++ b/changes.go
@@ -25,15 +25,6 @@ func (c *Changes) Err() error {
 	return c.iter.Err()
 }
 
-// Close closes the Changes feed, preventing further enumeration, and freeing
-// any resources (such as the http request body) of the underlying query. If
-// Next is called and there are no further results, Changes is closed
-// automatically and it will suffice to check the result of Err. Close is
-// idempotent and does not affect the result of Err.
-func (c *Changes) Close() error {
-	return c.iter.Close()
-}
-
 type changesIterator struct{ driver.Changes }
 
 var _ iterator = &changesIterator{}

--- a/changes.go
+++ b/changes.go
@@ -12,13 +12,6 @@ type Changes struct {
 	changesi driver.Changes
 }
 
-// Next prepares the next result value for reading. It returns true on success
-// or false if there are no more results, due to an error or the changes feed
-// having been closed. Err should be consulted to determine any error.
-func (c *Changes) Next() bool {
-	return c.iter.Next()
-}
-
 type changesIterator struct{ driver.Changes }
 
 var _ iterator = &changesIterator{}

--- a/iterator.go
+++ b/iterator.go
@@ -95,14 +95,6 @@ func (i *iter) next() (doClose, ok bool) {
 	return false, true
 }
 
-// EOQ returns true if the iterator has reached the end of a query in a
-// multi-query query. When EOQ is true, the row data will not have been
-// updated. It is common to simply `continue` in case of EOQ, unless you care
-// about the per-query metadata, such as offset, total rows, etc.
-func (i *iter) EOQ() bool {
-	return i.eoq
-}
-
 // Close closes the Iterator, preventing further enumeration, and freeing any
 // resources (such as the http request body) of the underlying feed. If Next is
 // called and there are no further results, Iterator is closed automatically and

--- a/iterator.go
+++ b/iterator.go
@@ -95,11 +95,11 @@ func (i *iter) next() (doClose, ok bool) {
 	return false, true
 }
 
-// Close closes the Iterator, preventing further enumeration, and freeing any
-// resources (such as the http request body) of the underlying feed. If Next is
-// called and there are no further results, Iterator is closed automatically and
-// it will suffice to check the result of Err. Close is idempotent and does not
-// affect the result of Err.
+// Close closes the iterator, preventing further enumeration, and freeing any
+// resources (such as the HTTP request body) of the underlying feed. If [Next]
+// is called and there are no further results, the iterator is closed
+// automatically and it will suffice to check the result of [Err]. Close is
+// idempotent and does not affect the result of [Err].
 func (i *iter) Close() error {
 	return i.close(nil)
 }

--- a/iterator.go
+++ b/iterator.go
@@ -66,7 +66,7 @@ func (i *iter) awaitDone(ctx context.Context) {
 
 // Next prepares the next iterator result value for reading. It returns true on
 // success, or false if there is no next result or an error occurs while
-// preparing it. Err should be consulted to distinguish between the two.
+// preparing it. [Err] should be consulted to distinguish between the two.
 func (i *iter) Next() bool {
 	doClose, ok := i.next()
 	if doClose {

--- a/iterator.go
+++ b/iterator.go
@@ -126,7 +126,7 @@ func (i *iter) close(err error) error {
 }
 
 // Err returns the error, if any, that was encountered during iteration. Err
-// may be called after an explicit or implicit Close.
+// may be called after an explicit or implicit [Close].
 func (i *iter) Err() error {
 	i.mu.RLock()
 	defer i.mu.RUnlock()

--- a/rows.go
+++ b/rows.go
@@ -13,13 +13,6 @@ type Rows struct {
 	rowsi driver.Rows
 }
 
-// Next prepares the next result value for reading. It returns true on success
-// or false if there are no more results or an error  occurs while preparing it.
-// Err should be consulted to distinguish between the two.
-func (r *Rows) Next() bool {
-	return r.iter.Next()
-}
-
 // EOQ returns true if the iterator has reached the end of a query in a
 // multi-query query. When EOQ is true, the row data will not have been
 // updated. It is common to simply `continue` in case of EOQ, unless you care

--- a/rows.go
+++ b/rows.go
@@ -35,6 +35,14 @@ func (r *Rows) Close() error {
 	return r.iter.Close()
 }
 
+// EOQ returns true if the iterator has reached the end of a query in a
+// multi-query query. When EOQ is true, the row data will not have been
+// updated. It is common to simply `continue` in case of EOQ, unless you care
+// about the per-query metadata, such as offset, total rows, etc.
+func (r *Rows) EOQ() bool {
+	return r.eoq
+}
+
 type rowsIterator struct{ driver.Rows }
 
 var _ iterator = &rowsIterator{}

--- a/rows.go
+++ b/rows.go
@@ -20,12 +20,6 @@ func (r *Rows) Next() bool {
 	return r.iter.Next()
 }
 
-// Err returns the error, if any, that was encountered during iteration. Err may
-// be called after an explicit or implicit Close.
-func (r *Rows) Err() error {
-	return r.iter.Err()
-}
-
 // EOQ returns true if the iterator has reached the end of a query in a
 // multi-query query. When EOQ is true, the row data will not have been
 // updated. It is common to simply `continue` in case of EOQ, unless you care

--- a/rows.go
+++ b/rows.go
@@ -26,15 +26,6 @@ func (r *Rows) Err() error {
 	return r.iter.Err()
 }
 
-// Close closes the Rows, preventing further enumeration, and freeing any
-// resources (such as the http request body) of the underlying query. If Next is
-// called and there are no further results, Rows is closed automatically and it
-// will suffice to check the result of Err. Close is idempotent and does not
-// affect the result of Err.
-func (r *Rows) Close() error {
-	return r.iter.Close()
-}
-
 // EOQ returns true if the iterator has reached the end of a query in a
 // multi-query query. When EOQ is true, the row data will not have been
 // updated. It is common to simply `continue` in case of EOQ, unless you care

--- a/updates.go
+++ b/updates.go
@@ -21,12 +21,6 @@ func (f *DBUpdates) Next() bool {
 	return f.iter.Next()
 }
 
-// Close closes the feed. Any unread updates will still be accessible via
-// Next().
-func (f *DBUpdates) Close() error {
-	return f.iter.Close()
-}
-
 // Err returns the error, if any, that was encountered during iteration. Err
 // may be called after an explicit or implicit Close.
 func (f *DBUpdates) Err() error {

--- a/updates.go
+++ b/updates.go
@@ -13,14 +13,6 @@ type DBUpdates struct {
 	updatesi driver.DBUpdates
 }
 
-// Next returns the next DBUpdate from the feed. This function will block
-// until an event is received. If an error occurs, it will be returned and
-// the feed closed. If the feed was closed normally, io.EOF will be returned
-// when there are no more events in the buffer.
-func (f *DBUpdates) Next() bool {
-	return f.iter.Next()
-}
-
 type updatesIterator struct{ driver.DBUpdates }
 
 var _ iterator = &updatesIterator{}

--- a/updates.go
+++ b/updates.go
@@ -21,12 +21,6 @@ func (f *DBUpdates) Next() bool {
 	return f.iter.Next()
 }
 
-// Err returns the error, if any, that was encountered during iteration. Err
-// may be called after an explicit or implicit Close.
-func (f *DBUpdates) Err() error {
-	return f.iter.Err()
-}
-
 type updatesIterator struct{ driver.DBUpdates }
 
 var _ iterator = &updatesIterator{}


### PR DESCRIPTION
And remove duplicate Next/Err/Close methods, relying on the promoted ones instead.