### PR TITLE
Change client.Close() semantics a bit

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -96,6 +96,9 @@ func (b *bufCloser) Close() error { return nil }
 
 // validate returns an error if the attachment is invalid.
 func (a *Attachment) validate() error {
+	if a == nil {
+		return missingArg("attachment")
+	}
 	if a.Filename == "" {
 		return missingArg("filename")
 	}

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -304,11 +304,24 @@ func TestBulkDocs(t *testing.T) { // nolint: gocyclo
 			},
 		},
 	})
+	tests.Add(errClientClosed, tt{
+		db: &DB{
+			client: &Client{
+				closed: 1,
+			},
+		},
+		docs: []interface{}{
+			map[string]string{"_id": "foo"},
+		},
+		status: http.StatusServiceUnavailable,
+		err:    errClientClosed,
+	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
 		result, err := tt.db.BulkDocs(context.Background(), tt.docs, tt.options)
 		testy.StatusError(t, tt.err, tt.status, err)
-		result.cancel = nil // Determinism
+		result.cancel = nil  // Determinism
+		result.onClose = nil // Determinism
 		if d := testy.DiffInterface(tt.expected, result); d != nil {
 			t.Error(d)
 		}

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -208,6 +208,7 @@ func TestBulkDocs(t *testing.T) { // nolint: gocyclo
 	tests := testy.NewTable()
 	tests.Add("invalid JSON", tt{
 		db: &DB{
+			client: &Client{},
 			driverDB: &mock.BulkDocer{
 				BulkDocsFunc: func(_ context.Context, docs []interface{}, _ map[string]interface{}) (driver.BulkResults, error) {
 					_, err := json.Marshal(docs)
@@ -221,6 +222,7 @@ func TestBulkDocs(t *testing.T) { // nolint: gocyclo
 	})
 	tests.Add("emulated BulkDocs support", tt{
 		db: &DB{
+			client: &Client{},
 			driverDB: &mock.DB{
 				PutFunc: func(_ context.Context, docID string, doc interface{}, opts map[string]interface{}) (string, error) {
 					if docID == "error" {
@@ -273,6 +275,7 @@ func TestBulkDocs(t *testing.T) { // nolint: gocyclo
 	})
 	tests.Add("new_edits", tt{
 		db: &DB{
+			client: &Client{},
 			driverDB: &mock.BulkDocer{
 				BulkDocsFunc: func(_ context.Context, docs []interface{}, opts map[string]interface{}) (driver.BulkResults, error) {
 					expectedDocs := []interface{}{map[string]string{"_id": "foo"}, 123}

--- a/cluster.go
+++ b/cluster.go
@@ -25,6 +25,10 @@ var clusterNotImplemented = &Error{Status: http.StatusNotImplemented, Message: "
 //
 // See http://docs.couchdb.org/en/stable/api/server/common.html#cluster-setup
 func (c *Client) ClusterStatus(ctx context.Context, options ...Options) (string, error) {
+	if err := c.startQuery(); err != nil {
+		return "", err
+	}
+	defer c.endQuery()
 	cluster, ok := c.driverClient.(driver.Cluster)
 	if !ok {
 		return "", clusterNotImplemented
@@ -38,6 +42,10 @@ func (c *Client) ClusterStatus(ctx context.Context, options ...Options) (string,
 //
 // See http://docs.couchdb.org/en/stable/api/server/common.html#post--_cluster_setup
 func (c *Client) ClusterSetup(ctx context.Context, action interface{}) error {
+	if err := c.startQuery(); err != nil {
+		return err
+	}
+	defer c.endQuery()
 	cluster, ok := c.driverClient.(driver.Cluster)
 	if !ok {
 		return clusterNotImplemented
@@ -58,6 +66,10 @@ type ClusterMembership struct {
 //
 // See https://docs.couchdb.org/en/latest/api/server/common.html#get--_membership
 func (c *Client) Membership(ctx context.Context) (*ClusterMembership, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
+	defer c.endQuery()
 	cluster, ok := c.driverClient.(driver.Cluster)
 	if !ok {
 		return nil, clusterNotImplemented

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -27,6 +27,7 @@ import (
 func TestClusterStatus(t *testing.T) {
 	type tst struct {
 		client   driver.Client
+		closed   int32
 		options  Options
 		expected string
 		status   int
@@ -55,10 +56,17 @@ func TestClusterStatus(t *testing.T) {
 		},
 		expected: "cluster_finished",
 	})
+	tests.Add("closed", tst{
+		client: &mock.Cluster{},
+		closed: 1,
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
+	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
 		c := &Client{
 			driverClient: test.client,
+			closed:       test.closed,
 		}
 		result, err := c.ClusterStatus(context.Background(), test.options)
 		testy.StatusError(t, test.err, test.status, err)
@@ -71,6 +79,7 @@ func TestClusterStatus(t *testing.T) {
 func TestClusterSetup(t *testing.T) {
 	type tst struct {
 		client driver.Client
+		closed int32
 		action interface{}
 		status int
 		err    string
@@ -98,10 +107,17 @@ func TestClusterSetup(t *testing.T) {
 			},
 		},
 	})
+	tests.Add("closed", tst{
+		client: &mock.Cluster{},
+		closed: 1,
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
+	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
 		c := &Client{
 			driverClient: test.client,
+			closed:       test.closed,
 		}
 		err := c.ClusterSetup(context.Background(), test.action)
 		testy.StatusError(t, test.err, test.status, err)
@@ -111,6 +127,7 @@ func TestClusterSetup(t *testing.T) {
 func TestMembership(t *testing.T) {
 	type tt struct {
 		client driver.Client
+		closed int32
 		want   *ClusterMembership
 		status int
 		err    string
@@ -145,10 +162,17 @@ func TestMembership(t *testing.T) {
 			ClusterNodes: []string{"one", "two"},
 		},
 	})
+	tests.Add("closed", tt{
+		client: &mock.Cluster{},
+		closed: 1,
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
+	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
 		c := &Client{
 			driverClient: tt.client,
+			closed:       tt.closed,
 		}
 		got, err := c.Membership(context.Background())
 		testy.StatusError(t, tt.err, tt.status, err)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -60,7 +60,7 @@ func TestClusterStatus(t *testing.T) {
 		client: &mock.Cluster{},
 		closed: 1,
 		status: http.StatusServiceUnavailable,
-		err:    "client closed",
+		err:    errClientClosed,
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
@@ -111,7 +111,7 @@ func TestClusterSetup(t *testing.T) {
 		client: &mock.Cluster{},
 		closed: 1,
 		status: http.StatusServiceUnavailable,
-		err:    "client closed",
+		err:    errClientClosed,
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
@@ -166,7 +166,7 @@ func TestMembership(t *testing.T) {
 		client: &mock.Cluster{},
 		closed: 1,
 		status: http.StatusServiceUnavailable,
-		err:    "client closed",
+		err:    errClientClosed,
 	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {

--- a/config.go
+++ b/config.go
@@ -34,6 +34,10 @@ var configNotImplemented = &Error{Status: http.StatusNotImplemented, Message: "k
 //
 // See http://docs.couchdb.org/en/stable/api/server/configuration.html#get--_node-node-name-_config
 func (c *Client) Config(ctx context.Context, node string) (Config, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
+	defer c.endQuery()
 	if configer, ok := c.driverClient.(driver.Configer); ok {
 		driverCf, err := configer.Config(ctx, node)
 		if err != nil {
@@ -53,6 +57,10 @@ func (c *Client) Config(ctx context.Context, node string) (Config, error) {
 //
 // See http://docs.couchdb.org/en/stable/api/server/configuration.html#node-node-name-config-section
 func (c *Client) ConfigSection(ctx context.Context, node, section string) (ConfigSection, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
+	defer c.endQuery()
 	if configer, ok := c.driverClient.(driver.Configer); ok {
 		sec, err := configer.ConfigSection(ctx, node, section)
 		return ConfigSection(sec), err
@@ -64,6 +72,10 @@ func (c *Client) ConfigSection(ctx context.Context, node, section string) (Confi
 //
 // See http://docs.couchdb.org/en/stable/api/server/configuration.html#get--_node-node-name-_config-section-key
 func (c *Client) ConfigValue(ctx context.Context, node, section, key string) (string, error) {
+	if err := c.startQuery(); err != nil {
+		return "", err
+	}
+	defer c.endQuery()
 	if configer, ok := c.driverClient.(driver.Configer); ok {
 		return configer.ConfigValue(ctx, node, section, key)
 	}
@@ -75,6 +87,10 @@ func (c *Client) ConfigValue(ctx context.Context, node, section, key string) (st
 //
 // See http://docs.couchdb.org/en/stable/api/server/configuration.html#put--_node-node-name-_config-section-key
 func (c *Client) SetConfigValue(ctx context.Context, node, section, key, value string) (string, error) {
+	if err := c.startQuery(); err != nil {
+		return "", err
+	}
+	defer c.endQuery()
 	if configer, ok := c.driverClient.(driver.Configer); ok {
 		return configer.SetConfigValue(ctx, node, section, key, value)
 	}
@@ -86,6 +102,10 @@ func (c *Client) SetConfigValue(ctx context.Context, node, section, key, value s
 //
 // See http://docs.couchdb.org/en/stable/api/server/configuration.html#delete--_node-node-name-_config-section-key
 func (c *Client) DeleteConfigKey(ctx context.Context, node, section, key string) (string, error) {
+	if err := c.startQuery(); err != nil {
+		return "", err
+	}
+	defer c.endQuery()
 	if configer, ok := c.driverClient.(driver.Configer); ok {
 		return configer.DeleteConfigKey(ctx, node, section, key)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -63,6 +63,13 @@ func TestConfig(t *testing.T) {
 			"foo": ConfigSection{"asd": "rew"},
 		},
 	})
+	tests.Add("closed", tst{
+		client: &Client{
+			closed: 1,
+		},
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
+	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
 		result, err := test.client.Config(context.Background(), test.node)
@@ -111,6 +118,13 @@ func TestConfigSection(t *testing.T) {
 		node:     "foo",
 		section:  "foo",
 		expected: ConfigSection{"lkj": "ghj"},
+	})
+	tests.Add("closed", tst{
+		client: &Client{
+			closed: 1,
+		},
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
@@ -164,6 +178,13 @@ func TestConfigValue(t *testing.T) {
 		section:  "foo",
 		key:      "asd",
 		expected: "jkl",
+	})
+	tests.Add("closed", tst{
+		client: &Client{
+			closed: 1,
+		},
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
@@ -222,6 +243,13 @@ func TestSetConfigValue(t *testing.T) {
 		value:    "baz",
 		expected: "old",
 	})
+	tests.Add("closed", tst{
+		client: &Client{
+			closed: 1,
+		},
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
+	})
 
 	tests.Run(t, func(t *testing.T, test tst) {
 		result, err := test.client.SetConfigValue(context.Background(), test.node, test.section, test.key, test.value)
@@ -274,6 +302,13 @@ func TestDeleteConfigKey(t *testing.T) {
 		section:  "foo",
 		key:      "baz",
 		expected: "old",
+	})
+	tests.Add("closed", tst{
+		client: &Client{
+			closed: 1,
+		},
+		status: http.StatusServiceUnavailable,
+		err:    "client closed",
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {

--- a/db.go
+++ b/db.go
@@ -618,7 +618,6 @@ func (db *DB) BulkGet(ctx context.Context, docs []BulkGetReference, options ...O
 // Close cleans up any resources used by the DB. The default CouchDB driver
 // does not use this, the default PouchDB driver does.
 func (db *DB) Close(ctx context.Context) error {
-	defer db.client.endQuery()
 	if db.err != nil {
 		return db.err
 	}

--- a/db.go
+++ b/db.go
@@ -618,6 +618,7 @@ func (db *DB) BulkGet(ctx context.Context, docs []BulkGetReference, options ...O
 // Close cleans up any resources used by the DB. The default CouchDB driver
 // does not use this, the default PouchDB driver does.
 func (db *DB) Close(ctx context.Context) error {
+	defer db.client.wg.Done()
 	if db.err != nil {
 		return db.err
 	}

--- a/db.go
+++ b/db.go
@@ -618,7 +618,7 @@ func (db *DB) BulkGet(ctx context.Context, docs []BulkGetReference, options ...O
 // Close cleans up any resources used by the DB. The default CouchDB driver
 // does not use this, the default PouchDB driver does.
 func (db *DB) Close(ctx context.Context) error {
-	defer db.client.wg.Done()
+	defer db.client.endQuery()
 	if db.err != nil {
 		return db.err
 	}

--- a/db.go
+++ b/db.go
@@ -728,13 +728,15 @@ type RevDiff struct {
 // the document ID.
 type Diffs map[string]RevDiff
 
-// RevsDiff the subset of document/revision IDs that do not correspond to
-// revisions stored in the database. This is used by the replication protocol,
-// and is normally never needed otherwise.  revMap must marshal to the expected
-// format.
+// RevsDiff returns the subset of document/revision IDs that do not correspond
+// to revisions stored in the database. This is used by the replication
+// protocol, and is normally never needed otherwise.  revMap must marshal to the
+// expected format.
 //
-// Use [ResultSet.ID] to return the current document ID, and ScanValue to access
-// the full JSON value, which should be of the JSON format:
+// Use [ResultSet.ID] to return the current document ID, and
+// [ResultSet.ScanValue] to access the full JSON value, which should be of the
+// JSON format. The [RevsDiff] type matches this format and is provided as a
+// convenience for unmarshaling.
 //
 //	{
 //	    "missing": ["rev1",...],

--- a/db_test.go
+++ b/db_test.go
@@ -2058,6 +2058,15 @@ func TestBulkGet(t *testing.T) {
 	}
 }
 
+func newDB(db driver.DB) *DB {
+	client := &Client{}
+	client.wg.Add(1)
+	return &DB{
+		client:   client,
+		driverDB: db,
+	}
+}
+
 func TestDBClose(t *testing.T) {
 	type tst struct {
 		db  *DB
@@ -2065,22 +2074,22 @@ func TestDBClose(t *testing.T) {
 	}
 	tests := testy.NewTable()
 	tests.Add("non-closer", tst{
-		db: &DB{driverDB: &mock.DB{}},
+		db: newDB(&mock.DB{}),
 	})
 	tests.Add("error", tst{
-		db: &DB{driverDB: &mock.DBCloser{
+		db: newDB(&mock.DBCloser{
 			CloseFunc: func(_ context.Context) error {
 				return errors.New("close err")
 			},
-		}},
+		}),
 		err: "close err",
 	})
 	tests.Add("success", tst{
-		db: &DB{driverDB: &mock.DBCloser{
+		db: newDB(&mock.DBCloser{
 			CloseFunc: func(_ context.Context) error {
 				return nil
 			},
-		}},
+		}),
 	})
 
 	tests.Run(t, func(t *testing.T, test tst) {

--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,35 @@ import (
 	"strings"
 )
 
+type err int
+
+var (
+	_ error       = err(0)
+	_ statusCoder = err(0)
+)
+
+const (
+	// ErrClientClosed is returned by any client operations after [Client.Close]
+	// has been called.
+	ErrClientClosed err = iota
+)
+
+func (e err) Error() string {
+	switch e {
+	case ErrClientClosed:
+		return "client closed"
+	}
+	return "unknown error"
+}
+
+func (e err) HTTPStatus() int {
+	switch e {
+	case ErrClientClosed:
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusInternalServerError
+}
+
 // Error represents an error returned by Kivik.
 //
 // This type definition is not guaranteed to remain stable, or even exported.

--- a/errors.go
+++ b/errors.go
@@ -32,10 +32,14 @@ const (
 	ErrClientClosed err = iota
 )
 
+const (
+	errClientClosed = "client closed"
+)
+
 func (e err) Error() string {
 	switch e {
 	case ErrClientClosed:
-		return "client closed"
+		return errClientClosed
 	}
 	return "unknown error"
 }

--- a/find.go
+++ b/find.go
@@ -28,12 +28,15 @@ func (db *DB) Find(ctx context.Context, query interface{}, options ...Options) R
 	if db.err != nil {
 		return &errRS{err: db.err}
 	}
+	if err := db.client.startQuery(); err != nil {
+		return &errRS{err: err}
+	}
 	if finder, ok := db.driverDB.(driver.Finder); ok {
 		rowsi, err := finder.Find(ctx, query, mergeOptions(options...))
 		if err != nil {
 			return &errRS{err: err}
 		}
-		return newRows(ctx, rowsi)
+		return newRows(ctx, db.client.endQuery, rowsi)
 	}
 	return &errRS{err: findNotImplemented}
 }

--- a/find.go
+++ b/find.go
@@ -43,6 +43,13 @@ func (db *DB) Find(ctx context.Context, query interface{}, options ...Options) R
 // index object, as described here:
 // http://docs.couchdb.org/en/stable/api/database/find.html#db-index
 func (db *DB) CreateIndex(ctx context.Context, ddoc, name string, index interface{}, options ...Options) error {
+	if db.err != nil {
+		return db.err
+	}
+	if err := db.client.startQuery(); err != nil {
+		return err
+	}
+	defer db.client.endQuery()
 	if finder, ok := db.driverDB.(driver.Finder); ok {
 		return finder.CreateIndex(ctx, ddoc, name, index, mergeOptions(options...))
 	}
@@ -51,6 +58,13 @@ func (db *DB) CreateIndex(ctx context.Context, ddoc, name string, index interfac
 
 // DeleteIndex deletes the requested index.
 func (db *DB) DeleteIndex(ctx context.Context, ddoc, name string, options ...Options) error {
+	if db.err != nil {
+		return db.err
+	}
+	if err := db.client.startQuery(); err != nil {
+		return err
+	}
+	defer db.client.endQuery()
 	if finder, ok := db.driverDB.(driver.Finder); ok {
 		return finder.DeleteIndex(ctx, ddoc, name, mergeOptions(options...))
 	}
@@ -67,6 +81,13 @@ type Index struct {
 
 // GetIndexes returns the indexes defined on the current database.
 func (db *DB) GetIndexes(ctx context.Context, options ...Options) ([]Index, error) {
+	if db.err != nil {
+		return nil, db.err
+	}
+	if err := db.client.startQuery(); err != nil {
+		return nil, err
+	}
+	defer db.client.endQuery()
 	if finder, ok := db.driverDB.(driver.Finder); ok {
 		dIndexes, err := finder.GetIndexes(ctx, mergeOptions(options...))
 		indexes := make([]Index, len(dIndexes))
@@ -97,6 +118,13 @@ type QueryPlan struct {
 // Explain returns the query plan for a given query. Explain takes the same
 // arguments as Find.
 func (db *DB) Explain(ctx context.Context, query interface{}, options ...Options) (*QueryPlan, error) {
+	if db.err != nil {
+		return nil, db.err
+	}
+	if err := db.client.startQuery(); err != nil {
+		return nil, err
+	}
+	defer db.client.endQuery()
 	if explainer, ok := db.driverDB.(driver.Finder); ok {
 		plan, err := explainer.Explain(ctx, query, mergeOptions(options...))
 		if err != nil {

--- a/internal/mock/bulkresults.go
+++ b/internal/mock/bulkresults.go
@@ -31,5 +31,8 @@ func (r *BulkResults) Next(result *driver.BulkResult) error {
 
 // Close calls r.CloseFunc
 func (r *BulkResults) Close() error {
-	return r.CloseFunc()
+	if r.CloseFunc != nil {
+		return r.CloseFunc()
+	}
+	return nil
 }

--- a/internal/mock/changes.go
+++ b/internal/mock/changes.go
@@ -47,12 +47,18 @@ func (c *Changes) Close() error {
 
 // LastSeq calls c.LastSeqFunc
 func (c *Changes) LastSeq() string {
-	return c.LastSeqFunc()
+	if c.LastSeqFunc != nil {
+		return c.LastSeqFunc()
+	}
+	return ""
 }
 
 // Pending calls c.PendingFunc
 func (c *Changes) Pending() int64 {
-	return c.PendingFunc()
+	if c.PendingFunc != nil {
+		return c.PendingFunc()
+	}
+	return 0
 }
 
 // ETag calls c.ETagFunc

--- a/internal/mock/dbupdates.go
+++ b/internal/mock/dbupdates.go
@@ -31,5 +31,8 @@ func (u *DBUpdates) Next(dbupdate *driver.DBUpdate) error {
 
 // Close calls u.CloseFunc
 func (u *DBUpdates) Close() error {
-	return u.CloseFunc()
+	if u.CloseFunc != nil {
+		return u.CloseFunc()
+	}
+	return nil
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -46,7 +46,7 @@ func (f *TestFeed) Next(ifce interface{}) error {
 }
 
 func TestIterator(t *testing.T) {
-	iter := newIterator(context.Background(), &TestFeed{max: 10}, func() interface{} { var i int64; return &i }())
+	iter := newIterator(context.Background(), nil, &TestFeed{max: 10}, func() interface{} { var i int64; return &i }())
 	expected := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	result := []int64{}
 	for iter.Next() {
@@ -67,7 +67,7 @@ func TestIterator(t *testing.T) {
 func TestCancelledIterator(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	iter := newIterator(ctx, &TestFeed{max: 10000}, func() interface{} { var i int64; return &i }())
+	iter := newIterator(ctx, nil, &TestFeed{max: 10000}, func() interface{} { var i int64; return &i }())
 	for iter.Next() { //nolint:revive // empty block necessary for loop
 	}
 	if err := iter.Err(); err.Error() != "context deadline exceeded" {

--- a/kivik.go
+++ b/kivik.go
@@ -144,9 +144,6 @@ func (c *Client) Version(ctx context.Context) (*Version, error) {
 // passed are merged, with later values taking precidence. If any errors occur
 // at this stage, they are deferred, or may be checked directly with [DB.Err].
 func (c *Client) DB(dbName string, options ...Options) *DB {
-	if err := c.startQuery(); err != nil {
-		return &DB{err: err}
-	}
 	db, err := c.driverClient.DB(dbName, mergeOptions(options...))
 	return &DB{
 		client:   c,
@@ -196,6 +193,10 @@ func (c *Client) DestroyDB(ctx context.Context, dbName string, options ...Option
 // is driver-specific. If the driver does not understand the authenticator, an
 // error will be returned.
 func (c *Client) Authenticate(ctx context.Context, a interface{}) error {
+	if err := c.startQuery(); err != nil {
+		return err
+	}
+	defer c.endQuery()
 	if auth, ok := c.driverClient.(driver.Authenticator); ok {
 		return auth.Authenticate(ctx, a)
 	}

--- a/kivik_test.go
+++ b/kivik_test.go
@@ -141,6 +141,14 @@ func TestVersion(t *testing.T) {
 			},
 			expected: &Version{Version: "foo"},
 		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -204,6 +212,14 @@ func TestDB(t *testing.T) {
 				},
 			}
 		}(),
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -253,6 +269,14 @@ func TestAllDBs(t *testing.T) {
 			},
 			options:  map[string]interface{}{"foo": 123},
 			expected: []string{"a", "b", "c"},
+		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
 		},
 	}
 	for _, test := range tests {
@@ -308,6 +332,14 @@ func TestDBExists(t *testing.T) {
 			dbName:   "foo",
 			options:  map[string]interface{}{"foo": 123},
 			expected: true,
+		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
 		},
 	}
 	for _, test := range tests {
@@ -365,6 +397,14 @@ func TestCreateDB(t *testing.T) {
 			dbName: "foo",
 			opts:   map[string]interface{}{"foo": 123},
 		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -414,6 +454,14 @@ func TestDestroyDB(t *testing.T) {
 			},
 			dbName: "foo",
 			opts:   map[string]interface{}{"foo": 123},
+		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
 		},
 	}
 	for _, test := range tests {
@@ -591,7 +639,7 @@ func TestDBsStats(t *testing.T) {
 			},
 			dbnames: []string{"foo", "bar"},
 			err:     "fallback failure",
-			status:  500,
+			status:  http.StatusInternalServerError,
 		},
 		{
 			name: "fallback db connect error",
@@ -604,7 +652,15 @@ func TestDBsStats(t *testing.T) {
 			},
 			dbnames: []string{"foo", "bar"},
 			err:     "db conn failure",
-			status:  500,
+			status:  http.StatusInternalServerError,
+		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
 		},
 	}
 	for _, test := range tests {
@@ -647,6 +703,13 @@ func TestPing(t *testing.T) {
 				},
 			},
 			expected: true,
+		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			err: "client closed",
 		},
 	}
 

--- a/kivik_test.go
+++ b/kivik_test.go
@@ -147,7 +147,7 @@ func TestVersion(t *testing.T) {
 				closed: 1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -268,7 +268,7 @@ func TestAllDBs(t *testing.T) {
 				closed: 1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -331,7 +331,7 @@ func TestDBExists(t *testing.T) {
 				closed: 1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -395,7 +395,7 @@ func TestCreateDB(t *testing.T) {
 				closed: 1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -453,7 +453,7 @@ func TestDestroyDB(t *testing.T) {
 				closed: 1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -514,7 +514,7 @@ func TestAuthenticate(t *testing.T) {
 				closed:       1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -661,7 +661,7 @@ func TestDBsStats(t *testing.T) {
 				closed: 1,
 			},
 			status: http.StatusServiceUnavailable,
-			err:    "client closed",
+			err:    errClientClosed,
 		},
 	}
 	for _, test := range tests {
@@ -710,7 +710,7 @@ func TestPing(t *testing.T) {
 			client: &Client{
 				closed: 1,
 			},
-			err: "client closed",
+			err: errClientClosed,
 		},
 	}
 

--- a/kivik_test.go
+++ b/kivik_test.go
@@ -212,14 +212,6 @@ func TestDB(t *testing.T) {
 				},
 			}
 		}(),
-		{
-			name: "closed",
-			client: &Client{
-				closed: 1,
-			},
-			status: http.StatusServiceUnavailable,
-			err:    "client closed",
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -514,6 +506,15 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 			auth: int(3),
+		},
+		{
+			name: "closed",
+			client: &Client{
+				driverClient: &mock.Authenticator{},
+				closed:       1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
 		},
 	}
 	for _, test := range tests {
@@ -820,18 +821,6 @@ func TestClientClose(t *testing.T) {
 		}
 
 		tests := testy.NewTable()
-		tests.Add("open DB", tt{
-			client: &mock.Client{
-				DBFunc: func(string, map[string]interface{}) (driver.DB, error) {
-					return &mock.DB{}, nil
-				},
-			},
-			work: func(c *Client) {
-				db := c.DB("foo")
-				time.Sleep(delay)
-				_ = db.Close(context.TODO())
-			},
-		})
 		tests.Add("AllDBs", tt{
 			client: &mock.Client{
 				AllDBsFunc: func(context.Context, map[string]interface{}) ([]string, error) {

--- a/replication.go
+++ b/replication.go
@@ -171,6 +171,10 @@ var replicationNotImplemented = &Error{Status: http.StatusNotImplemented, Messag
 // database. Options are in the same format as to AllDocs(), except that
 // "conflicts" and "update_seq" are ignored.
 func (c *Client) GetReplications(ctx context.Context, options ...Options) ([]*Replication, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
+	defer c.endQuery()
 	replicator, ok := c.driverClient.(driver.ClientReplicator)
 	if !ok {
 		return nil, replicationNotImplemented
@@ -191,6 +195,10 @@ func (c *Client) GetReplications(ctx context.Context, options ...Options) ([]*Re
 // To use an object for either "source" or "target", pass the desired object
 // in options. This will override targetDSN and sourceDSN function parameters.
 func (c *Client) Replicate(ctx context.Context, targetDSN, sourceDSN string, options ...Options) (*Replication, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
+	defer c.endQuery()
 	replicator, ok := c.driverClient.(driver.ClientReplicator)
 	if !ok {
 		return nil, replicationNotImplemented

--- a/replication_test.go
+++ b/replication_test.go
@@ -369,6 +369,14 @@ func TestGetReplications(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -440,6 +448,14 @@ func TestReplicate(t *testing.T) {
 				Target: "a-target",
 				irep:   &mock.Replication{ID: "a"},
 			},
+		},
+		{
+			name: "closed",
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
 		},
 	}
 	for _, test := range tests {

--- a/resultset.go
+++ b/resultset.go
@@ -210,9 +210,9 @@ func (r *rowsIterator) Next(i interface{}) error {
 	return err
 }
 
-func newRows(ctx context.Context, rowsi driver.Rows) *rows {
+func newRows(ctx context.Context, onClose func(), rowsi driver.Rows) *rows {
 	return &rows{
-		iter:  newIterator(ctx, &rowsIterator{Rows: rowsi}, &driver.Row{}),
+		iter:  newIterator(ctx, onClose, &rowsIterator{Rows: rowsi}, &driver.Row{}),
 		rowsi: rowsi,
 	}
 }

--- a/resultset_test.go
+++ b/resultset_test.go
@@ -124,7 +124,7 @@ func TestRowsScanValue(t *testing.T) {
 			},
 		}
 		return tt{
-			rows:     newRows(context.Background(), rowsi),
+			rows:     newRows(context.Background(), nil, rowsi),
 			expected: "foo",
 			state:    stateClosed,
 		}
@@ -210,7 +210,7 @@ func TestRowsScanDoc(t *testing.T) {
 			},
 		}
 		return tt{
-			rows:     newRows(context.Background(), rowsi),
+			rows:     newRows(context.Background(), nil, rowsi),
 			expected: map[string]interface{}{"foo": "bar"},
 			state:    stateClosed,
 		}
@@ -295,7 +295,7 @@ func TestRowsScanKey(t *testing.T) {
 			},
 		}
 		return tt{
-			rows:     newRows(context.Background(), rowsi),
+			rows:     newRows(context.Background(), nil, rowsi),
 			expected: "foo",
 			state:    stateClosed,
 		}
@@ -389,7 +389,7 @@ func TestRowsGetters(t *testing.T) {
 					return nil
 				},
 			}
-			r := newRows(context.Background(), rowsi)
+			r := newRows(context.Background(), nil, rowsi)
 
 			result, _ := r.ID()
 			if result != id {
@@ -404,7 +404,7 @@ func TestRowsGetters(t *testing.T) {
 					return nil
 				},
 			}
-			r := newRows(context.Background(), rowsi)
+			r := newRows(context.Background(), nil, rowsi)
 
 			result, _ := r.Key()
 			if result != string(key) {
@@ -464,7 +464,7 @@ func TestRowsGetters(t *testing.T) {
 
 func TestMetadata(t *testing.T) {
 	t.Run("iteration incomplete", func(t *testing.T) {
-		r := newRows(context.Background(), &mock.Rows{
+		r := newRows(context.Background(), nil, &mock.Rows{
 			OffsetFunc:    func() int64 { return 123 },
 			TotalRowsFunc: func() int64 { return 234 },
 			UpdateSeqFunc: func() string { return "seq" },
@@ -490,7 +490,7 @@ func TestMetadata(t *testing.T) {
 	}
 
 	t.Run("Standard", func(t *testing.T) {
-		r := newRows(context.Background(), &mock.Rows{
+		r := newRows(context.Background(), nil, &mock.Rows{
 			OffsetFunc:    func() int64 { return 123 },
 			TotalRowsFunc: func() int64 { return 234 },
 			UpdateSeqFunc: func() string { return "seq" },
@@ -499,14 +499,14 @@ func TestMetadata(t *testing.T) {
 	})
 	t.Run("Bookmarker", func(t *testing.T) {
 		expected := "test bookmark"
-		r := newRows(context.Background(), &mock.Bookmarker{
+		r := newRows(context.Background(), nil, &mock.Bookmarker{
 			BookmarkFunc: func() string { return expected },
 		})
 		check(t, r)
 	})
 	t.Run("Warner", func(t *testing.T) {
 		expected := "test warning"
-		r := newRows(context.Background(), &mock.RowsWarner{
+		r := newRows(context.Background(), nil, &mock.RowsWarner{
 			WarningFunc: func() string { return expected },
 		})
 		check(t, r)
@@ -518,7 +518,7 @@ func TestMetadata(t *testing.T) {
 			&driver.Row{Doc: strings.NewReader(`{"foo":"bar"}`)},
 		}
 
-		r := newRows(context.Background(), &mock.Rows{
+		r := newRows(context.Background(), nil, &mock.Rows{
 			NextFunc: func(r *driver.Row) error {
 				if len(rows) == 0 {
 					return io.EOF
@@ -550,7 +550,7 @@ func TestMetadata(t *testing.T) {
 			&driver.Row{Doc: strings.NewReader(`{"foo":"bar"}`)},
 		}
 
-		r := newRows(context.Background(), &mock.Rows{
+		r := newRows(context.Background(), nil, &mock.Rows{
 			NextFunc: func(r *driver.Row) error {
 				if len(rows) == 0 {
 					return io.EOF
@@ -630,7 +630,7 @@ func TestScanAllDocs(t *testing.T) {
 		err:  "0-length array passed to ScanAllDocs",
 	})
 	tests.Add("No docs to read", tt{
-		rows: newRows(context.Background(), &mock.Rows{}),
+		rows: newRows(context.Background(), nil, &mock.Rows{}),
 		dest: func() *[]string { return &[]string{} }(),
 	})
 	tests.Add("Success", func() interface{} {
@@ -638,7 +638,7 @@ func TestScanAllDocs(t *testing.T) {
 			{Doc: strings.NewReader(`{"foo":"bar"}`)},
 		}
 		return tt{
-			rows: newRows(context.Background(), &mock.Rows{
+			rows: newRows(context.Background(), nil, &mock.Rows{
 				NextFunc: func(r *driver.Row) error {
 					if len(rows) == 0 {
 						return io.EOF
@@ -656,7 +656,7 @@ func TestScanAllDocs(t *testing.T) {
 			{Doc: strings.NewReader(`{"foo":"bar"}`)},
 		}
 		return tt{
-			rows: newRows(context.Background(), &mock.Rows{
+			rows: newRows(context.Background(), nil, &mock.Rows{
 				NextFunc: func(r *driver.Row) error {
 					if len(rows) == 0 {
 						return io.EOF
@@ -674,7 +674,7 @@ func TestScanAllDocs(t *testing.T) {
 			{Doc: strings.NewReader(`{"foo":"bar"}`)},
 		}
 		return tt{
-			rows: newRows(context.Background(), &mock.Rows{
+			rows: newRows(context.Background(), nil, &mock.Rows{
 				NextFunc: func(r *driver.Row) error {
 					if len(rows) == 0 {
 						return io.EOF
@@ -694,7 +694,7 @@ func TestScanAllDocs(t *testing.T) {
 			{Doc: strings.NewReader(`{"foo":"bar"}`)},
 		}
 		return tt{
-			rows: newRows(context.Background(), &mock.Rows{
+			rows: newRows(context.Background(), nil, &mock.Rows{
 				NextFunc: func(r *driver.Row) error {
 					if len(rows) == 0 {
 						return io.EOF
@@ -709,7 +709,7 @@ func TestScanAllDocs(t *testing.T) {
 	})
 	tests.Run(t, func(t *testing.T, tt tt) {
 		if tt.rows == nil {
-			tt.rows = newRows(context.Background(), &mock.Rows{})
+			tt.rows = newRows(context.Background(), nil, &mock.Rows{})
 		}
 		err := ScanAllDocs(tt.rows, tt.dest)
 		if !testy.ErrorMatches(tt.err, err) {
@@ -807,7 +807,7 @@ func multiResultSet() ResultSet {
 	}
 	var offset int64
 
-	return newRows(context.Background(), &mock.Rows{
+	return newRows(context.Background(), nil, &mock.Rows{
 		NextFunc: func(r *driver.Row) error {
 			if len(rows) == 0 {
 				return io.EOF
@@ -832,7 +832,7 @@ func multiResultSet() ResultSet {
 }
 
 func Test_bug576(t *testing.T) {
-	rows := newRows(context.Background(), &mock.Rows{
+	rows := newRows(context.Background(), nil, &mock.Rows{
 		NextFunc: func(*driver.Row) error {
 			return io.EOF
 		},

--- a/session.go
+++ b/session.go
@@ -42,6 +42,10 @@ type Session struct {
 
 // Session returns information about the currently authenticated user.
 func (c *Client) Session(ctx context.Context) (*Session, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
+	defer c.endQuery()
 	if sessioner, ok := c.driverClient.(driver.Sessioner); ok {
 		session, err := sessioner.Session(ctx)
 		if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -28,6 +28,7 @@ func TestSession(t *testing.T) {
 	tests := []struct {
 		name     string
 		client   driver.Client
+		closed   int32
 		expected interface{}
 		status   int
 		err      string
@@ -63,10 +64,19 @@ func TestSession(t *testing.T) {
 				Roles: []string{"stooges"},
 			},
 		},
+		{
+			name:   "closed",
+			closed: 1,
+			status: http.StatusServiceUnavailable,
+			err:    "client closed",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := &Client{driverClient: test.client}
+			client := &Client{
+				driverClient: test.client,
+				closed:       test.closed,
+			}
 			session, err := client.Session(context.Background())
 			var errMsg string
 			if err != nil {

--- a/updates.go
+++ b/updates.go
@@ -68,15 +68,12 @@ func (f *DBUpdates) Seq() string {
 
 // DBUpdates begins polling for database updates.
 func (c *Client) DBUpdates(ctx context.Context, options ...Options) (*DBUpdates, error) {
-	var updaterFunc func(context.Context, map[string]interface{}) (driver.DBUpdates, error)
-	switch t := c.driverClient.(type) {
-	case driver.DBUpdater:
-		updaterFunc = t.DBUpdates
-	default:
+	updater, ok := c.driverClient.(driver.DBUpdater)
+	if !ok {
 		return nil, &Error{Status: http.StatusNotImplemented, Message: "kivik: driver does not implement DBUpdater"}
 	}
 
-	updatesi, err := updaterFunc(ctx, mergeOptions(options...))
+	updatesi, err := updater.DBUpdates(ctx, mergeOptions(options...))
 	if err != nil {
 		return nil, err
 	}

--- a/updates.go
+++ b/updates.go
@@ -30,9 +30,9 @@ var _ iterator = &updatesIterator{}
 
 func (r *updatesIterator) Next(i interface{}) error { return r.DBUpdates.Next(i.(*driver.DBUpdate)) }
 
-func newDBUpdates(ctx context.Context, updatesi driver.DBUpdates) *DBUpdates {
+func newDBUpdates(ctx context.Context, onClose func(), updatesi driver.DBUpdates) *DBUpdates {
 	return &DBUpdates{
-		iter: newIterator(ctx, &updatesIterator{updatesi}, &driver.DBUpdate{}),
+		iter: newIterator(ctx, onClose, &updatesIterator{updatesi}, &driver.DBUpdate{}),
 	}
 }
 
@@ -68,6 +68,9 @@ func (f *DBUpdates) Seq() string {
 
 // DBUpdates begins polling for database updates.
 func (c *Client) DBUpdates(ctx context.Context, options ...Options) (*DBUpdates, error) {
+	if err := c.startQuery(); err != nil {
+		return nil, err
+	}
 	updater, ok := c.driverClient.(driver.DBUpdater)
 	if !ok {
 		return nil, &Error{Status: http.StatusNotImplemented, Message: "kivik: driver does not implement DBUpdater"}
@@ -77,5 +80,5 @@ func (c *Client) DBUpdates(ctx context.Context, options ...Options) (*DBUpdates,
 	if err != nil {
 		return nil, err
 	}
-	return newDBUpdates(context.Background(), updatesi), nil
+	return newDBUpdates(context.Background(), c.endQuery, updatesi), nil
 }

--- a/updates_test.go
+++ b/updates_test.go
@@ -92,7 +92,7 @@ func TestDBUpdatesIteratorNext(t *testing.T) {
 }
 
 func TestDBUpdatesIteratorNew(t *testing.T) {
-	u := newDBUpdates(context.Background(), &mock.DBUpdates{})
+	u := newDBUpdates(context.Background(), nil, &mock.DBUpdates{})
 	expected := &DBUpdates{
 		iter: &iter{
 			feed: &updatesIterator{
@@ -215,12 +215,21 @@ func TestDBUpdates(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: errClientClosed,
+			client: &Client{
+				closed: 1,
+			},
+			status: http.StatusServiceUnavailable,
+			err:    errClientClosed,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := test.client.DBUpdates(context.Background())
 			testy.StatusError(t, test.err, test.status, err)
-			result.cancel = nil // Determinism
+			result.cancel = nil  // Determinism
+			result.onClose = nil // Determinism
 			if d := testy.DiffInterface(test.expected, result); d != nil {
 				t.Error(d)
 			}


### PR DESCRIPTION
- Make Close() block until all subordinate DB operations complete
- Make all other calls fail once Close() is called

Relates to #611 