### PR TITLE
Remove legacy support for the github.com/pkg/errors.causer interface

### DIFF
--- a/couchdb/chttp/errors.go
+++ b/couchdb/chttp/errors.go
@@ -81,10 +81,6 @@ func fullError(httpStatus int, err error) error {
 	}
 }
 
-func (e *curlError) Cause() error {
-	return e.error
-}
-
 func (e *curlError) Unwrap() error {
 	return e.error
 }

--- a/couchdb/mock_test.go
+++ b/couchdb/mock_test.go
@@ -122,7 +122,7 @@ func realDB(t *testing.T) *db {
 	}
 	db, err := realDBConnect(t)
 	if err != nil {
-		if _, ok := errors.Cause(err).(*url.Error); ok {
+		if errors.Is(err, &url.Error{}) {
 			t.Skip("Cannot connect to CouchDB")
 		}
 		if strings.HasSuffix(err.Error(), "connect: connection refused") {

--- a/errors.go
+++ b/errors.go
@@ -80,7 +80,6 @@ type Error struct {
 var (
 	_ error       = &Error{}
 	_ statusCoder = &Error{}
-	_ causer      = &Error{}
 )
 
 func (e *Error) Error() string {
@@ -100,11 +99,6 @@ func (e *Error) HTTPStatus() int {
 		return http.StatusInternalServerError
 	}
 	return e.Status
-}
-
-// Cause satisfies the github.com/pkg/errors.causer interface by returning e.Err.
-func (e *Error) Cause() error {
-	return e.Err
 }
 
 // Unwrap satisfies the errors.Wrapper interface.
@@ -143,10 +137,6 @@ type statusCoder interface {
 	HTTPStatus() int
 }
 
-type causer interface {
-	Cause() error
-}
-
 // HTTPStatus returns the HTTP status code embedded in the error, or 500
 // (internal server error), if there was no specified status code.  If err is
 // nil, HTTPStatus returns 0. This provides a convenient way to determine the
@@ -181,10 +171,6 @@ func HTTPStatus(err error) int {
 		}
 		if uw := errors.Unwrap(err); uw != nil {
 			err = uw
-			continue
-		}
-		if c, ok := err.(causer); ok {
-			err = c.Cause()
 			continue
 		}
 		return http.StatusInternalServerError


### PR DESCRIPTION
It was made obsolete with the advent of Go 1.13.  I think we can stop supporting it now.