### PR TITLE
Use empty string to indicate CouchDB 1.x config node

### DIFF
--- a/couchdb/config.go
+++ b/couchdb/config.go
@@ -24,15 +24,15 @@ import (
 	"github.com/go-kivik/kivik/v4/driver"
 )
 
-// Couch1ConfigNode can be passed to any of the Config-related methods as the
+// couch1ConfigNode can be passed to any of the Config-related methods as the
 // node name, to query the /_config endpoint in a CouchDB 1.x-compatible way.
-const Couch1ConfigNode = "<Couch1Config>"
+const couch1ConfigNode = ""
 
 var _ driver.Configer = &client{}
 
 func configURL(node string, parts ...string) string {
 	var components []string
-	if node == Couch1ConfigNode {
+	if node == couch1ConfigNode {
 		components = append(make([]string, 0, len(parts)+1),
 			"_config")
 	} else {

--- a/couchdb/config_test.go
+++ b/couchdb/config_test.go
@@ -43,7 +43,7 @@ func TestConfig(t *testing.T) {
 	})
 	tests.Add("Couch 1.x path", tst{
 		client: newTestClient(nil, errors.New("net error")),
-		node:   Couch1ConfigNode,
+		node:   couch1ConfigNode,
 		status: http.StatusBadGateway,
 		err:    `^Get "?http://example.com/_config"?: net error$`,
 	})
@@ -85,7 +85,7 @@ func TestConfigSection(t *testing.T) {
 	})
 	tests.Add("Couch 1.x path", tst{
 		client:  newTestClient(nil, errors.New("net error")),
-		node:    Couch1ConfigNode,
+		node:    couch1ConfigNode,
 		section: "foo",
 		status:  http.StatusBadGateway,
 		err:     `^Get "?http://example.com/_config/foo"?: net error$`,
@@ -128,7 +128,7 @@ func TestConfigValue(t *testing.T) {
 	})
 	tests.Add("Couch 1.x path", tst{
 		client:  newTestClient(nil, errors.New("net error")),
-		node:    Couch1ConfigNode,
+		node:    couch1ConfigNode,
 		section: "foo",
 		key:     "bar",
 		status:  http.StatusBadGateway,
@@ -173,7 +173,7 @@ func TestSetConfigValue(t *testing.T) {
 	})
 	tests.Add("Couch 1.x path", tst{
 		client:  newTestClient(nil, errors.New("net error")),
-		node:    Couch1ConfigNode,
+		node:    couch1ConfigNode,
 		section: "foo",
 		key:     "bar",
 		status:  http.StatusBadGateway,
@@ -230,7 +230,7 @@ func TestDeleteConfigKey(t *testing.T) {
 	})
 	tests.Add("Couch 1.x path", tst{
 		client:  newTestClient(nil, errors.New("net error")),
-		node:    Couch1ConfigNode,
+		node:    couch1ConfigNode,
 		section: "foo",
 		key:     "bar",
 		status:  http.StatusBadGateway,

--- a/couchdb/doc.go
+++ b/couchdb/doc.go
@@ -116,6 +116,18 @@ inline base-64 encoding the attachments.  Example:
 
 	rev, err := db.Put(ctx, "user123", doc", couchdb.OptionNoMultipartPut())
 
+# Server config for CouchDB 1.x
+
+CouchDB allows querying the server configuration via the /_config endpoint. This
+is supported with the [github.com/go-kivik/kivik/v4.DB.Config],
+[github.com/go-kivik/kivik/v4.DB.ConfigSection],
+[github.com/go-kivik/kivik/v4.DB.ConfigValue],
+[github.com/go-kivik/kivik/v4.DB.SetConfigValue], and
+[github.com/go-kivik/kivik/v4.DB.DeleteConfigKey] methods. Each of these methods
+accepts a node argument, but CouchDB 1.x does not support per-node configuration
+via this endpoint. If you are still using CouchDB 1.x, leave the node argument
+empty, and this driver will revert to CouchDB-compatible operation.
+
 [upload multiple attachments]: http://docs.couchdb.org/en/stable/api/document/common.html#creating-multiple-attachments
 */
 package couchdb


### PR DESCRIPTION
Fixes #694 