### PR TITLE
Tag rc2

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -14,7 +14,7 @@ package kivik
 
 const (
 	// Version is the version of the Kivik library.
-	Version = "4.0.0-rc1"
+	Version = "4.0.1-rc2"
 )
 
 // SessionCookieName is the name of the CouchDB session cookie.


### PR DESCRIPTION
I decided to skip over a 4.0.0 release, and go straight to 4.0.1, because the `kivik` command line tool, imported from another repo, was previously tagged '4.0.0`, so to avoidy any confusion or ambiguity about which version someone is running, I'll do straight to 4.0.1.