### PR TITLE
Bump version to 4.3.0

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -14,7 +14,7 @@ package kivik
 
 const (
 	// Version is the version of the Kivik library.
-	Version = "4.2.4"
+	Version = "4.3.0"
 )
 
 // SessionCookieName is the name of the CouchDB session cookie.


### PR DESCRIPTION
To reflect new Go 1.23 iterator functions

Also adds PouchDB 9 to tests.