### PR TITLE
Bump GitHub action workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.12"
 
       - name: Determine tag name
         run: |
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create Release
         if: ${{ env.TAG != '' }}
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           tag: ${{ env.TAG }}
           commit: master


### PR DESCRIPTION
This PR bumps GitHub action workflows to their latest versions, thus avoiding deprecation warnings as seen [here](https://github.com/go-kivik/kivik/actions/runs/10013626152).