### PR TITLE
Remove the outdated build constraint `// +build`

### DIFF
--- a/attachments123_test.go
+++ b/attachments123_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.23
-// +build go1.23
 
 package kivik
 

--- a/changes123_test.go
+++ b/changes123_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.23
-// +build go1.23
 
 package kivik
 

--- a/couchdb/chttp/chttp_js_test.go
+++ b/couchdb/chttp/chttp_js_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package chttp
 

--- a/couchdb/main_js_test.go
+++ b/couchdb/main_js_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package couchdb
 

--- a/couchdb/session_test.go
+++ b/couchdb/session_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 // GopherJS can't run a test server
 

--- a/couchdb/test/couchdb_test.go
+++ b/couchdb/test/couchdb_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package test
 

--- a/internal/nettest/nettest.go
+++ b/internal/nettest/nettest.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 // Package nettest wraps [httptest.NewServer] to skip when called from GopherJS.
 package nettest

--- a/internal/nettest/nettest_js.go
+++ b/internal/nettest/nettest_js.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 // Package nettest wraps [httptest.NewServer] to skip when called from GopherJS.
 package nettest

--- a/kiviktest/client/replicate_js.go
+++ b/kiviktest/client/replicate_js.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package client
 

--- a/kiviktest/client/replicate_nonjs.go
+++ b/kiviktest/client/replicate_nonjs.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package client
 

--- a/kiviktest/go110testing.go
+++ b/kiviktest/go110testing.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.10 && !go1.18
-// +build go1.10,!go1.18
 
 package kiviktest
 

--- a/kiviktest/go118testing.go
+++ b/kiviktest/go118testing.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.18 && !go1.23
-// +build go1.18,!go1.23
 
 package kiviktest
 

--- a/kiviktest/go123testing.go
+++ b/kiviktest/go123testing.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.23
-// +build go1.23
 
 package kiviktest
 

--- a/kiviktest/go18testing.go
+++ b/kiviktest/go18testing.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.8 && !go1.9
-// +build go1.8,!go1.9
 
 package kiviktest
 

--- a/pouchdb/README.md
+++ b/pouchdb/README.md
@@ -22,7 +22,7 @@ interface. You must import the driver and can then use the full
 [`Kivik`](http://pkg.go.dev/github.com/go-kivik/kivik/v4) API.
 
 ```go
-// +build js
+//go:build js
 
 package main
 

--- a/pouchdb/attachments.go
+++ b/pouchdb/attachments.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/basicauth.go
+++ b/pouchdb/basicauth.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/bindings/errors.go
+++ b/pouchdb/bindings/errors.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package bindings
 

--- a/pouchdb/bindings/errors_test.go
+++ b/pouchdb/bindings/errors_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package bindings
 

--- a/pouchdb/bindings/nofind_test.go
+++ b/pouchdb/bindings/nofind_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package bindings
 

--- a/pouchdb/bindings/pouchdb.go
+++ b/pouchdb/bindings/pouchdb.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 // Package bindings provides minimal GopherJS bindings around the PouchDB
 // library. (https://pouchdb.com/api.html)

--- a/pouchdb/bindings/poucherr/poucherr.go
+++ b/pouchdb/bindings/poucherr/poucherr.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 // Package poucherr exists only for the purpose of testing the PouchDB binding's
 // handling of PouchDB-specific error messages. This Go package is empty, the

--- a/pouchdb/bindings/recover.go
+++ b/pouchdb/bindings/recover.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package bindings
 

--- a/pouchdb/bulk.go
+++ b/pouchdb/bulk.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/changes.go
+++ b/pouchdb/changes.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/changes_test.go
+++ b/pouchdb/changes_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/db.go
+++ b/pouchdb/db.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/db_test.go
+++ b/pouchdb/db_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/doc.go
+++ b/pouchdb/doc.go
@@ -21,7 +21,7 @@ Use the `pouch` driver name when using this driver. The DSN should be the
 blank string for local database connections, or a full URL, including any
 required credentials, when connecting to a remote database.
 
-	// +build js
+	//go:build js
 
 	package main
 

--- a/pouchdb/find.go
+++ b/pouchdb/find.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/find_test.go
+++ b/pouchdb/find_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/indexeddb/purge_test.go
+++ b/pouchdb/indexeddb/purge_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package indexeddb
 

--- a/pouchdb/internal/pouchver.go
+++ b/pouchdb/internal/pouchver.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package internal
 

--- a/pouchdb/js.go
+++ b/pouchdb/js.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package pouchdb
 

--- a/pouchdb/pouchdb.go
+++ b/pouchdb/pouchdb.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/replication.go
+++ b/pouchdb/replication.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/replicationEvents.go
+++ b/pouchdb/replicationEvents.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/rows.go
+++ b/pouchdb/rows.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package pouchdb
 

--- a/pouchdb/test/pouchdb_test.go
+++ b/pouchdb/test/pouchdb_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 package test
 

--- a/pouchdb/test/test.go
+++ b/pouchdb/test/test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build js
-// +build js
 
 // Package test provides PouchDB integration tests.
 package test

--- a/replicate_live_test.go
+++ b/replicate_live_test.go
@@ -13,7 +13,6 @@
 // TODO: Try to re-enable these tests when we're on a newer version of GopherJS.
 
 //go:build !js
-// +build !js
 
 package kivik_test
 

--- a/resultset123_test.go
+++ b/resultset123_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.23
-// +build go1.23
 
 package kivik
 

--- a/updates123_test.go
+++ b/updates123_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.23
-// +build go1.23
 
 package kivik
 

--- a/x/fsdb/test/fs_test.go
+++ b/x/fsdb/test/fs_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package test
 

--- a/x/kivikd/auth.go
+++ b/x/kivikd/auth.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/auth/cookie/cookie.go
+++ b/x/kivikd/auth/cookie/cookie.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 // Package cookie provides standard CouchDB cookie auth as described at
 // http://docs.couchdb.org/en/2.0.0/api/server/authn.html#cookie-authentication

--- a/x/kivikd/auth/cookie/cookie_test.go
+++ b/x/kivikd/auth/cookie/cookie_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package cookie
 

--- a/x/kivikd/authdb/authgroup/authgroup.go
+++ b/x/kivikd/authdb/authgroup/authgroup.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package authgroup
 

--- a/x/kivikd/authdb/authgroup/authgroup_test.go
+++ b/x/kivikd/authdb/authgroup/authgroup_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package authgroup
 

--- a/x/kivikd/authdb/confadmin/confadmin.go
+++ b/x/kivikd/authdb/confadmin/confadmin.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package confadmin
 

--- a/x/kivikd/authdb/confadmin/confadmin_test.go
+++ b/x/kivikd/authdb/confadmin/confadmin_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package confadmin
 

--- a/x/kivikd/authdb/couchauth/invalidurl_test.go
+++ b/x/kivikd/authdb/couchauth/invalidurl_test.go
@@ -1,5 +1,4 @@
 //go:build 1.8
-// +build 1.8
 
 package couchauth
 

--- a/x/kivikd/conf/conf.go
+++ b/x/kivikd/conf/conf.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package conf
 

--- a/x/kivikd/conf/conf_test.go
+++ b/x/kivikd/conf/conf_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package conf
 

--- a/x/kivikd/context.go
+++ b/x/kivikd/context.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/cookies.go
+++ b/x/kivikd/cookies.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/cookies_test.go
+++ b/x/kivikd/cookies_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/couchserver/alldbs.go
+++ b/x/kivikd/couchserver/alldbs.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/alldbs_test.go
+++ b/x/kivikd/couchserver/alldbs_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/context.go
+++ b/x/kivikd/couchserver/context.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/context_test.go
+++ b/x/kivikd/couchserver/context_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/couchserver.go
+++ b/x/kivikd/couchserver/couchserver.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/couchserver_test.go
+++ b/x/kivikd/couchserver/couchserver_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/db.go
+++ b/x/kivikd/couchserver/db.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/db_test.go
+++ b/x/kivikd/couchserver/db_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/errors.go
+++ b/x/kivikd/couchserver/errors.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/errors_test.go
+++ b/x/kivikd/couchserver/errors_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/favicon.go
+++ b/x/kivikd/couchserver/favicon.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/favicon_test.go
+++ b/x/kivikd/couchserver/favicon_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/root.go
+++ b/x/kivikd/couchserver/root.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/root_test.go
+++ b/x/kivikd/couchserver/root_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/session.go
+++ b/x/kivikd/couchserver/session.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/couchserver/session_test.go
+++ b/x/kivikd/couchserver/session_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package couchserver
 

--- a/x/kivikd/formbind.go
+++ b/x/kivikd/formbind.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/logger.go
+++ b/x/kivikd/logger.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/logger_test.go
+++ b/x/kivikd/logger_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/params.go
+++ b/x/kivikd/params.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/routes.go
+++ b/x/kivikd/routes.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/serve.go
+++ b/x/kivikd/serve.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/serve_test.go
+++ b/x/kivikd/serve_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/session.go
+++ b/x/kivikd/session.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package kivikd
 

--- a/x/kivikd/test/server_test.go
+++ b/x/kivikd/test/server_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package test
 

--- a/x/kivikd/test/test.go
+++ b/x/kivikd/test/test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package test
 

--- a/x/memorydb/rand.go
+++ b/x/memorydb/rand.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build go1.8
-// +build go1.8
 
 package memorydb
 

--- a/x/memorydb/rand_17.go
+++ b/x/memorydb/rand_17.go
@@ -1,5 +1,4 @@
 //go:build go1.7 && !go1.8
-// +build go1.7,!go1.8
 
 package memorydb
 

--- a/x/server/auth.go
+++ b/x/server/auth.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/bind.go
+++ b/x/server/bind.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/cluster.go
+++ b/x/server/cluster.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/cluster_test.go
+++ b/x/server/cluster_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/config.go
+++ b/x/server/config.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/db.go
+++ b/x/server/db.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/db_test.go
+++ b/x/server/db_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/docs.go
+++ b/x/server/docs.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/errors.go
+++ b/x/server/errors.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/middleware.go
+++ b/x/server/middleware.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/options.go
+++ b/x/server/options.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/security.go
+++ b/x/server/security.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/server.go
+++ b/x/server/server.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/server_test.go
+++ b/x/server/server_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/stats.go
+++ b/x/server/stats.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/userstore.go
+++ b/x/server/userstore.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/utils.go
+++ b/x/server/utils.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/server/uuid.go
+++ b/x/server/uuid.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package server
 

--- a/x/sqlite/changes_test.go
+++ b/x/sqlite/changes_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/collation_test.go
+++ b/x/sqlite/collation_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/common_test.go
+++ b/x/sqlite/common_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/db_test.go
+++ b/x/sqlite/db_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/delete_test.go
+++ b/x/sqlite/delete_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/deleteattachment_test.go
+++ b/x/sqlite/deleteattachment_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/designdocs_test.go
+++ b/x/sqlite/designdocs_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/get_test.go
+++ b/x/sqlite/get_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/getattachment_test.go
+++ b/x/sqlite/getattachment_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/getattachmentmeta_test.go
+++ b/x/sqlite/getattachmentmeta_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/getrev_test.go
+++ b/x/sqlite/getrev_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/json_test.go
+++ b/x/sqlite/json_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/localdocs_test.go
+++ b/x/sqlite/localdocs_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/openrevs_test.go
+++ b/x/sqlite/openrevs_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/purge_test.go
+++ b/x/sqlite/purge_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/put_designdocs_test.go
+++ b/x/sqlite/put_designdocs_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/put_test.go
+++ b/x/sqlite/put_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/putattachment_test.go
+++ b/x/sqlite/putattachment_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/query_test.go
+++ b/x/sqlite/query_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/reduce_test.go
+++ b/x/sqlite/reduce_test.go
@@ -11,6 +11,5 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite

--- a/x/sqlite/revsdiff_test.go
+++ b/x/sqlite/revsdiff_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/sqlite_test.go
+++ b/x/sqlite/sqlite_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/templ.go
+++ b/x/sqlite/templ.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/util_test.go
+++ b/x/sqlite/util_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 

--- a/x/sqlite/views_test.go
+++ b/x/sqlite/views_test.go
@@ -11,7 +11,6 @@
 // the License.
 
 //go:build !js
-// +build !js
 
 package sqlite
 


### PR DESCRIPTION
This PR removes outdated `// +build` comments. The ["Build constraints"](https://pkg.go.dev/cmd/go#hdr-Build_constraints) states:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

So, using only `//go:build` for Go 1.17+ is perfectly fine.

I used this command to remove lines starting with `// +build`:
```sh
find . -name '*.go' -exec sed -i '' '/^\/\/ +build/d' {} +
```