### PR TITLE
Fix typos in comments, tests, and docs

### DIFF
--- a/cmd/kivik/README.md
+++ b/cmd/kivik/README.md
@@ -194,7 +194,7 @@ Further, by providing the `--yaml` flag, or by reading from a file with a `.yml`
 
 ## Network Controls
 
-`kivik` provides a number of network configuratione parameters to facilitate working during network problems, or while waiting for a CouchDB server to come online.
+`kivik` provides a number of network configuration parameters to facilitate working during network problems, or while waiting for a CouchDB server to come online.
 
 
       --request-timeout string       The time limit for each request.

--- a/cmd/kivik/errors/errors.go
+++ b/cmd/kivik/errors/errors.go
@@ -35,7 +35,7 @@ const (
 	// error.
 	ErrInternalServerError = 4
 
-	// ErrBadReuqest indicates that the server responded with a 400 error.
+	// ErrBadRequest indicates that the server responded with a 400 error.
 	ErrBadRequest = 10
 	// ErrUnauthorized indicates that the server responded with a 401 error.
 	ErrUnauthorized = 11

--- a/couchdb/chttp/chttp_test.go
+++ b/couchdb/chttp/chttp_test.go
@@ -500,7 +500,7 @@ func TestGetRev(t *testing.T) {
 			expected: `12345`,
 		},
 		{
-			name: "satndard ETag header",
+			name: "standard ETag header",
 			resp: &http.Response{
 				StatusCode: 200,
 				Request:    &http.Request{Method: "POST"},

--- a/couchdb/chttp/trace_test.go
+++ b/couchdb/chttp/trace_test.go
@@ -100,7 +100,7 @@ func TestHTTPRequest(t *testing.T) {
 			finalReq: httptest.NewRequest("PUT", "/", io.NopCloser(strings.NewReader("testing"))),
 		},
 		{
-			name: "HTTPRequesteBody/cloned response",
+			name: "HTTPRequestBody/cloned response",
 			trace: func(t *testing.T) *ClientTrace {
 				return &ClientTrace{
 					HTTPRequestBody: func(r *http.Request) {
@@ -119,7 +119,7 @@ func TestHTTPRequest(t *testing.T) {
 			finalReq: httptest.NewRequest("PUT", "/", io.NopCloser(strings.NewReader("testing"))),
 		},
 		{
-			name: "HTTPRequeste/cloned response",
+			name: "HTTPRequest/cloned response",
 			trace: func(t *testing.T) *ClientTrace {
 				return &ClientTrace{
 					HTTPRequest: func(r *http.Request) {
@@ -137,7 +137,7 @@ func TestHTTPRequest(t *testing.T) {
 			finalReq: httptest.NewRequest("PUT", "/", io.NopCloser(strings.NewReader("testing"))),
 		},
 		{
-			name: "HTTPRequesteBody/no body",
+			name: "HTTPRequestBody/no body",
 			trace: func(t *testing.T) *ClientTrace {
 				return &ClientTrace{
 					HTTPRequestBody: func(r *http.Request) {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -127,7 +127,7 @@ type ReplicationInfo struct {
 type ClientReplicator interface {
 	// Replicate initiates a replication.
 	Replicate(ctx context.Context, targetDSN, sourceDSN string, options Options) (Replication, error)
-	// GetReplications returns a list of replicatoins (i.e. all docs in the
+	// GetReplications returns a list of replications (i.e. all docs in the
 	// _replicator database)
 	GetReplications(ctx context.Context, options Options) ([]Replication, error)
 }
@@ -237,7 +237,7 @@ type DocCreator interface {
 	CreateDoc(ctx context.Context, doc interface{}, options Options) (docID, rev string, err error)
 }
 
-// OpenRever is an ptional interface that extends a [DB] to support the open_revs
+// OpenRever is an optional interface that extends a [DB] to support the open_revs
 // option of the CouchDB get document endpoint. It is used by the replicator.
 // Drivers that don't support this endpoint may not be able to replicate as
 // efficiently, or at all.

--- a/driver/partition.go
+++ b/driver/partition.go
@@ -18,7 +18,7 @@ import (
 )
 
 // PartitionedDB is an optional interface that may be implemented by a [DB] to
-// support querying partitoin-specific information.
+// support querying partition-specific information.
 type PartitionedDB interface {
 	// PartitionStats returns information about the named partition.
 	PartitionStats(ctx context.Context, name string) (*PartitionStats, error)

--- a/int/mock/replication.go
+++ b/int/mock/replication.go
@@ -56,7 +56,7 @@ func (r *Replication) Err() error {
 	return r.ErrFunc()
 }
 
-// ReplicationID calls r.ReplicatoinIDFunc
+// ReplicationID calls r.ReplicationIDFunc
 func (r *Replication) ReplicationID() string {
 	return r.ReplicationIDFunc()
 }

--- a/iterator.go
+++ b/iterator.go
@@ -98,7 +98,7 @@ func newIterator(ctx context.Context, onClose func(), feed iterator, zeroValue i
 	return i
 }
 
-// errIterator instantiates a new iteratore that is already closed, and only
+// errIterator instantiates a new iterator that is already closed, and only
 // returns an error.
 func errIterator(err error) *iter {
 	return &iter{

--- a/mockdb/clientmock.go
+++ b/mockdb/clientmock.go
@@ -88,7 +88,7 @@ func (c *Client) open() (*kivik.Client, *Client, error) {
 	return client, c, err
 }
 
-// ExpectationsWereMet returns an error if any outstanding expectatios were
+// ExpectationsWereMet returns an error if any outstanding expectations were
 // not met.
 func (c *Client) ExpectationsWereMet() error {
 	c.drv.Lock()

--- a/pouchdb/bindings/pouchdb.go
+++ b/pouchdb/bindings/pouchdb.go
@@ -440,7 +440,7 @@ func (db *DB) GetIndexes(ctx context.Context) (*js.Object, error) {
 
 // DeleteIndex deletes an index used by the MongoDB-style queries with the
 // pouchdb-find plugin, if it is installed. If the plugin is not installed, a
-// NotImplemeneted error will be returned.
+// NotImplemented error will be returned.
 //
 // See: https://github.com/pouchdb/pouchdb/tree/master/packages/node_modules/pouchdb-find#dbdeleteindexindex--callback
 func (db *DB) DeleteIndex(ctx context.Context, index interface{}) (*js.Object, error) {

--- a/replicate.go
+++ b/replicate.go
@@ -149,7 +149,7 @@ func (r *replicator) replicate(ctx context.Context, options Option) error {
 type replicator struct {
 	target, source *DB
 	cb             eventCallback
-	// withSecurity indicates that the secuurity object should be read from
+	// withSecurity indicates that the security object should be read from
 	// source, and copied to the target, before the replication. Use with
 	// caution! The security object is not versioned, and will be
 	// unconditionally overwritten!

--- a/x/fsdb/cdb/revid.go
+++ b/x/fsdb/cdb/revid.go
@@ -32,7 +32,7 @@ func (r *RevID) Changed() bool {
 	return r.String() != r.original
 }
 
-// UnmarshalText xatisfies the json.Unmarshaler interface.
+// UnmarshalText satisfies the json.Unmarshaler interface.
 func (r *RevID) UnmarshalText(p []byte) error {
 	r.original = string(p)
 	if bytes.Contains(p, []byte("-")) {

--- a/x/fsdb/changes.go
+++ b/x/fsdb/changes.go
@@ -12,7 +12,7 @@
 
 // Changes feed support
 //
-// At present, this driver provides only rudamentary Changes feed support. It
+// At present, this driver provides only rudimentary Changes feed support. It
 // supports only one-off changes feeds (no continuous support), and this is
 // implemented by scanning the database directory, and returning each document
 // and its most recent revision only.

--- a/x/mango/ast_test.go
+++ b/x/mango/ast_test.go
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 		input:   `{"foo": {"$invalid": "bar"}}`,
 		wantErr: "invalid operator $invalid",
 	})
-	tests.Add("explicit equiality against object", test{
+	tests.Add("explicit equality against object", test{
 		input: `{"foo": {"$eq": {"bar": "baz"}}}`,
 		want: &fieldNode{
 			field: "foo",

--- a/x/server/auth.go
+++ b/x/server/auth.go
@@ -131,11 +131,11 @@ func (s *Server) dbMembershipRequired(next httpe.HandlerWithError) httpe.Handler
 	})
 }
 
-// validateDBMembership returns an error if the user lacks sufficient membersip.
+// validateDBMembership returns an error if the user lacks sufficient membership.
 //
 //	See the [CouchDB documentation] for the rules for granting access.
 //
-// [CouchDB documentatio]: https://docs.couchdb.org/en/stable/api/database/security.html#get--db-_security
+// [CouchDB documentation]: https://docs.couchdb.org/en/stable/api/database/security.html#get--db-_security
 func validateDBMembership(user *auth.UserContext, security *kivik.Security) error {
 	// No membership names/roles means open read access.
 	if len(security.Members.Names) == 0 && len(security.Members.Roles) == 0 {
@@ -188,11 +188,11 @@ func (s *Server) dbAdminRequired(next httpe.HandlerWithError) httpe.HandlerWithE
 	})
 }
 
-// validateDBAdmin returns an error if the user lacks sufficient membersip.
+// validateDBAdmin returns an error if the user lacks sufficient membership.
 //
 //	See the [CouchDB documentation] for the rules for granting access.
 //
-// [CouchDB documentatio]: https://docs.couchdb.org/en/stable/api/database/security.html#get--db-_security
+// [CouchDB documentation]: https://docs.couchdb.org/en/stable/api/database/security.html#get--db-_security
 func validateDBAdmin(user *auth.UserContext, security *kivik.Security) error {
 	if user == nil {
 		return &internal.Error{Status: http.StatusUnauthorized, Message: "User not authenticated"}

--- a/x/server/auth/auth.go
+++ b/x/server/auth/auth.go
@@ -68,7 +68,7 @@ type AuthenticateFunc func(http.ResponseWriter, *http.Request) (*UserContext, er
 
 // Handler is an auth handler.
 type Handler interface {
-	// Init should return the name of the authenticatoin method, and an
+	// Init should return the name of the authentication method, and an
 	// authentication function. It is only called once on server startup.
 	Init(Server) (string, AuthenticateFunc)
 }

--- a/x/server/config/config.go
+++ b/x/server/config/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Config provides access to read server configuration. Configuration
-// backends that allow modifying configuraiont will also implement
+// backends that allow modifying configuration will also implement
 // [ConfigWriter].
 type Config interface {
 	All(context.Context) (map[string]map[string]string, error)

--- a/x/sqlite/options.go
+++ b/x/sqlite/options.go
@@ -792,7 +792,7 @@ func (v viewOptions) reduceGroupLevel() int {
 }
 
 // viewOptions are all of the options recognized by the view endpoints
-// _desgin/<ddoc>/_view/<view>, _all_docs, _design_docs, and _local_docs.
+// _design/<ddoc>/_view/<view>, _all_docs, _design_docs, and _local_docs.
 //
 // See https://docs.couchdb.org/en/stable/api/ddoc/views.html#api-ddoc-view
 type viewOptions struct {

--- a/x/sqlite/options_test.go
+++ b/x/sqlite/options_test.go
@@ -44,7 +44,7 @@ func Test_viewOptions(t *testing.T) {
 			sorted:       true,
 		},
 	})
-	tests.Add("confclits: invalid string", test{
+	tests.Add("conflicts: invalid string", test{
 		options:    kivik.Param("conflicts", "oink"),
 		wantErr:    "invalid value for 'conflicts': oink",
 		wantStatus: http.StatusBadRequest,


### PR DESCRIPTION
The PR corrects spelling mistakes in comments, test case names, and documentation files.