### PR TITLE
fix(couchdb): use url.PathEscape in DBExists for consistency with other DB* methods

### DIFF
--- a/couchdb/client.go
+++ b/couchdb/client.go
@@ -40,7 +40,7 @@ func (c *client) DBExists(ctx context.Context, dbName string, _ driver.Options) 
 	if dbName == "" {
 		return false, missingArg("dbName")
 	}
-	_, err := c.DoError(ctx, http.MethodHead, dbName, nil)
+	_, err := c.DoError(ctx, http.MethodHead, url.PathEscape(dbName), nil)
 	if kivik.HTTPStatus(err) == http.StatusNotFound {
 		return false, nil
 	}

--- a/couchdb/client_test.go
+++ b/couchdb/client_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -119,6 +120,22 @@ func TestDBExists(t *testing.T) {
 			name:   "exists, 1.6.1",
 			dbName: "foo",
 			client: newTestClient(&http.Response{
+				StatusCode: 200,
+				Header: http.Header{
+					"Server":         {"CouchDB/1.6.1 (Erlang OTP/17)"},
+					"Date":           {"Fri, 27 Oct 2017 15:09:19 GMT"},
+					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Content-Length": {"229"},
+					"Cache-Control":  {"must-revalidate"},
+				},
+				Body: Body(""),
+			}, nil),
+			exists: true,
+		},
+		{
+			name:   "slashes",
+			dbName: "foo/bar",
+			client: newTestClientWithRawPath("/"+url.PathEscape("foo/bar"), &http.Response{
 				StatusCode: 200,
 				Header: http.Header{
 					"Server":         {"CouchDB/1.6.1 (Erlang OTP/17)"},

--- a/couchdb/mock_test.go
+++ b/couchdb/mock_test.go
@@ -15,6 +15,7 @@ package couchdb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -59,6 +60,23 @@ func newTestClient(response *http.Response, err error) *client {
 		}
 		if err != nil {
 			return nil, err
+		}
+		response := response
+		response.Request = req
+		return response, nil
+	})
+}
+
+func newTestClientWithRawPath(path string, response *http.Response, err error) *client {
+	return newCustomClient(func(req *http.Request) (*http.Response, error) {
+		if e := consume(req.Body); e != nil {
+			return nil, e
+		}
+		if err != nil {
+			return nil, err
+		}
+		if req.URL.RawPath != path {
+			return nil, fmt.Errorf("expected path %s, got %s", path, req.URL.Path)
 		}
 		response := response
 		response.Request = req

--- a/couchdb/mock_test.go
+++ b/couchdb/mock_test.go
@@ -15,7 +15,6 @@ package couchdb
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -60,23 +59,6 @@ func newTestClient(response *http.Response, err error) *client {
 		}
 		if err != nil {
 			return nil, err
-		}
-		response := response
-		response.Request = req
-		return response, nil
-	})
-}
-
-func newTestClientWithRawPath(path string, response *http.Response, err error) *client {
-	return newCustomClient(func(req *http.Request) (*http.Response, error) {
-		if e := consume(req.Body); e != nil {
-			return nil, e
-		}
-		if err != nil {
-			return nil, err
-		}
-		if req.URL.RawPath != path {
-			return nil, fmt.Errorf("expected path %s, got %s", path, req.URL.Path)
 		}
 		response := response
 		response.Request = req


### PR DESCRIPTION
Currently, `url.PathEncode` is applied for `CreateDB` and `DestroyDB`, but not for `DBExists`, which behave inconsistently.

I discovered this when I created a database that included special characters, but `DBExists` would not correctly detect a database even after being created.

For a reproducible example, I could not find a good test case to update, as the request path is never part of the test assertion. You can reproduce the issue with the following setup:

**docker-compose.yml**
```yaml
services:
  couchdb:
    image: couchdb:3
    ports:
      - 5984:5984
    environment:
      COUCHDB_USER: admin
      COUCHDB_PASSWORD: password
```

**go.mod**
```
module kivik-testing

go 1.23.0

require github.com/go-kivik/kivik/v4 v4.3.0

require (
	github.com/google/uuid v1.6.0 // indirect
	golang.org/x/net v0.17.0 // indirect
	golang.org/x/sync v0.4.0 // indirect
)
```

**main.go**
```go
package main

import (
	"context"
	"log"
	"net/http"
	"net/url"

	"github.com/go-kivik/kivik/v4"
	_ "github.com/go-kivik/kivik/v4/couchdb"
)

func main() {
	ctx := context.Background()

	couchdb, err := kivik.New("couch", "http://admin:password@localhost:5984")
	if err != nil {
		log.Fatal(err)
	}

	dbName := "foo/bar"

	// ensure database is created
	if err := couchdb.CreateDB(ctx, dbName); err != nil {
		switch kivik.HTTPStatus(err) {
		case http.StatusPreconditionFailed:
			// do nothing, database already exists
		default:
			log.Fatalf("failed to create database %s: %s", dbName, err)
		}
	}

	// check existence with existing kivik
	exists, err := couchdb.DBExists(ctx, dbName)
	if err != nil {
		log.Fatalf("failed to check database %s existence", dbName)
	}
	log.Printf("exists (got %t, expected true)", exists)

	// check existince with hack
	exists, err = couchdb.DBExists(ctx, url.PathEscape(dbName))
	if err != nil {
		log.Fatalf("failed to check database %s existence", dbName)
	}
	log.Printf("exists with hack (got %t, expected true)", exists)
}
```
Upon running my "test" script, I get the following output:

```sh
$ go run .
exists (got false, expected true)
exists with hack (got true, expected true)
```

This PR includes a fix, which is to use `url.PathEscape` within `DBExists` which mirrors `CreateDB` and `DestroyDB` and will produce consistent/correct behavior.

It would be nice to validate this fix with a test case, but I don't think the current test suite really has this kind of assertion baked in (it kinda assumes the right URL path is used, since it just returns the configured `*http.Response` no matter what the request).