### PR TITLE
x/mango: Fix evaluation of `$exists: false` always failing

### DIFF
--- a/x/collate/collate.go
+++ b/x/collate/collate.go
@@ -73,6 +73,11 @@ func CompareObject(a, b interface{}) int {
 			return -1
 		}
 		return 1
+	case jsonTypeNull:
+		if b == nil {
+			return 0
+		}
+		return -1
 	case jsonTypeNumber:
 		return int(a.(float64) - b.(float64))
 	case jsonTypeString:

--- a/x/mango/match_test.go
+++ b/x/mango/match_test.go
@@ -444,6 +444,53 @@ func TestMatch(t *testing.T) {
 		doc:  "bar",
 		want: false,
 	})
+	tests.Add("field selector, nested", test{
+		sel: &fieldNode{
+			field: "foo.bar.baz",
+			cond: &conditionNode{
+				op:   OpEqual,
+				cond: "hello",
+			},
+		},
+		doc: map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": map[string]interface{}{
+					"baz": "hello",
+				},
+			},
+		},
+		want: true,
+	})
+	tests.Add("field selector, nested, non-object", test{
+		sel: &fieldNode{
+			field: "foo.bar.baz",
+			cond: &conditionNode{
+				op:   OpEqual,
+				cond: "hello",
+			},
+		},
+		doc: map[string]interface{}{
+			"foo": "hello",
+		},
+		want: false,
+	})
+	tests.Add("!field selector, nested", test{
+		sel: &fieldNode{
+			field: "foo.bar.baz",
+			cond: &conditionNode{
+				op:   OpEqual,
+				cond: "hello",
+			},
+		},
+		doc: map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": map[string]interface{}{
+					"buzz": "hello",
+				},
+			},
+		},
+		want: false,
+	})
 	tests.Add("elemMatch", test{
 		sel: &fieldNode{
 			field: "foo",

--- a/x/mango/match_test.go
+++ b/x/mango/match_test.go
@@ -129,35 +129,43 @@ func TestMatch(t *testing.T) {
 		want: false,
 	})
 	tests.Add("exists", test{
-		sel: &conditionNode{
-			op:   OpExists,
-			cond: true,
+		sel: &fieldNode{
+			field: "foo",
+			cond:  &conditionNode{op: OpExists, cond: true},
 		},
-		doc:  "foo",
+		doc: map[string]interface{}{
+			"foo": "bar",
+		},
 		want: true,
 	})
 	tests.Add("!exists", test{
-		sel: &conditionNode{
-			op:   OpExists,
-			cond: false,
+		sel: &fieldNode{
+			field: "baz",
+			cond:  &conditionNode{op: OpExists, cond: true},
 		},
-		doc:  "foo",
+		doc: map[string]interface{}{
+			"foo": "bar",
+		},
 		want: false,
 	})
 	tests.Add("not exists", test{
-		sel: &conditionNode{
-			op:   OpExists,
-			cond: false,
+		sel: &fieldNode{
+			field: "baz",
+			cond:  &conditionNode{op: OpExists, cond: false},
 		},
-		doc:  nil,
+		doc: map[string]interface{}{
+			"foo": "bar",
+		},
 		want: true,
 	})
 	tests.Add("!not exists", test{
-		sel: &conditionNode{
-			op:   OpExists,
-			cond: true,
+		sel: &fieldNode{
+			field: "baz",
+			cond:  &conditionNode{op: OpExists, cond: true},
 		},
-		doc:  nil,
+		doc: map[string]interface{}{
+			"foo": "bar",
+		},
 		want: false,
 	})
 	tests.Add("type, null", test{

--- a/x/mango/selector.go
+++ b/x/mango/selector.go
@@ -127,14 +127,20 @@ func (f *fieldNode) String() string {
 }
 
 func (f *fieldNode) Match(doc interface{}) bool {
-	m, ok := doc.(map[string]interface{})
-	if !ok {
-		return false
+	val := doc
+
+	// Traverse nested fields (e.g. "foo.bar.baz")
+	segments := strings.Split(f.field, ".")
+	for _, segment := range segments {
+		m, ok := val.(map[string]interface{})
+		if !ok {
+			return false
+		}
+
+		val = m[segment]
 	}
-	val, ok := m[f.field]
-	if !ok {
-		return false
-	}
+
+	// Even if the field does not exist we need to pass it to the condition expression because of `$exists`
 	return f.cond.Match(val)
 }
 


### PR DESCRIPTION
This PR fixes the evaluation of `$exists: false` by making `fieldNode.Match()` always pass the value to the condition, even if it is not found in the map.

It also makes it possible to do subfield lookups using dot notation (e.g. `foo.bar.baz`) as mentioned in the [CouchDB documentation](https://docs.couchdb.org/en/stable/api/database/find.html#subfields).

This PR fixes https://github.com/go-kivik/kivik/issues/1043.