### PR TITLE
Treat objects-as-success from pouchdb info, as Go errors

### DIFF
--- a/pouchdb/bindings/errors_test.go
+++ b/pouchdb/bindings/errors_test.go
@@ -15,6 +15,7 @@
 package bindings
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/gopherjs/gopherjs/js"
@@ -51,6 +52,31 @@ func TestNewPouchError(t *testing.T) {
 			Expected:       "error name: error reason",
 		},
 		{
+			Name: "PouchDB Remote info returns an error-like response for not-found",
+			/*
+				{
+					error: 'not_found',
+					reason: 'Database does not exist.',
+					host: 'http://localhost:32800/kivik%24alldbsstats_admin%246550ad7f92f36665/',
+					db_name: 'http://localhost:32800/kivik$alldbsstats_admin$6550ad7f92f36665',
+					auto_compaction: false,
+					adapter: 'http'
+				}
+			*/
+			Object: func() *js.Object {
+				o := js.Global.Get("Object").New()
+				o.Set("error", "not_found")
+				o.Set("reason", "Database does not exist.")
+				o.Set("host", "http://localhost:32800/kivik%24alldbsstats_admin%246550ad7f92f36665/")
+				o.Set("db_name", "http://localhost:32800/kivik$alldbsstats_admin$6550ad7f92f36665")
+				o.Set("auto_compaction", false)
+				o.Set("adapter", "http")
+				return o
+			}(),
+			ExpectedStatus: http.StatusNotFound,
+			Expected:       "not_found: Database does not exist.",
+		},
+		{
 			Name: "ECONNREFUSED",
 			Object: js.Global.Call("ReconstitutePouchError", `{
                 "code":    "ECONNREFUSED",
@@ -71,7 +97,7 @@ func TestNewPouchError(t *testing.T) {
                         "last_seq": 0
                     }
                 }`),
-			ExpectedStatus: 500,
+			ExpectedStatus: http.StatusInternalServerError,
 			Expected:       "Error: connection refused",
 		},
 	}

--- a/pouchdb/db.go
+++ b/pouchdb/db.go
@@ -143,12 +143,15 @@ func (d *db) Delete(ctx context.Context, docID string, options driver.Options) (
 
 func (d *db) Stats(ctx context.Context) (*driver.DBStats, error) {
 	i, err := d.db.Info(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &driver.DBStats{
 		Name:           i.Name,
 		CompactRunning: atomic.LoadUint32(&d.compacting) == 1 || atomic.LoadUint32(&d.viewCleanup) == 1,
 		DocCount:       i.DocCount,
 		UpdateSeq:      i.UpdateSeq,
-	}, err
+	}, nil
 }
 
 func (d *db) Compact(context.Context) error {


### PR DESCRIPTION
The db info method in PouchDB sometimes (always?) returns an object with error values, rather than an error. WTF?  Not sure when that changed, or how I missed it.  This accounts for that, with the two observed error types. There are likely others that should be accounted for as well.